### PR TITLE
Use time for priority handling

### DIFF
--- a/build/makefile
+++ b/build/makefile
@@ -5,10 +5,10 @@
 -include ../makefile.init
 
 RM := rm -rf
-OPT_LVL := ${VFRB_OPT}
+OPT_LVL := $(or ${VFRB_OPT},${VFRB_OPT},3)
 DBG := ${VFRB_DEBUG}
 TARGET := ${VFRB_TARGET}
-CXX := ${VFRB_COMPILER}
+CXX := $(or ${VFRB_COMPILER},${VFRB_COMPILER},g++)
 BOOST_L := ${BOOST_LIBS_L}
 BOOST_I := ${BOOST_ROOT_I}
 

--- a/build/src/subdir.mk
+++ b/build/src/subdir.mk
@@ -6,16 +6,19 @@
 CPP_SRCS += \
 ../src/Main.cpp \
 ../src/VFRB.cpp \
+../src/Signals.cpp \
 ../src/Logger.cpp
 
 OBJS += \
 ./src/Main.o \
 ./src/VFRB.o \
+./src/Signals.o \
 ./src/Logger.o
 
 CPP_DEPS += \
 ./src/Main.d \
 ./src/VFRB.d \
+./src/Signals.d \
 ./src/Logger.d
 
 V_VERSION := ${VFRB_VERSION}

--- a/src/Defines.h
+++ b/src/Defines.h
@@ -118,17 +118,3 @@
     TYPE& operator=(const TYPE&) = delete; \
     TYPE(TYPE&&);                          \
     TYPE& operator=(TYPE&&);
-
-/// @def DEFAULT_CTOR_DTOR
-/// Define default constructor and destructor for a class of TYPE.
-#define DEFAULT_CTOR_DTOR(TYPE) \
-    TYPE();                     \
-    virtual ~TYPE() noexcept;
-
-/// @def DEFAULT_CTOR_DTOR_INLINE
-/// Define and declare default constructor and destructor for a class of TYPE.
-#define DEFAULT_CTOR_DTOR_INLINE(TYPE) \
-    TYPE()                             \
-    {}                                 \
-    virtual ~TYPE() noexcept           \
-    {}

--- a/src/Defines.h
+++ b/src/Defines.h
@@ -107,7 +107,7 @@
 
 /// @def NON_COPYABLE
 /// Make a class of TYPE non copyable.
-#define NON_COPYABLE(TYPE)      \
+#define NOT_COPYABLE(TYPE)      \
     TYPE(const TYPE&) = delete; \
     TYPE& operator=(const TYPE&) = delete;
 

--- a/src/Logger.cpp
+++ b/src/Logger.cpp
@@ -22,7 +22,6 @@
 #include "Logger.hpp"
 
 #include <ctime>
-#include <string>
 #include <boost/chrono.hpp>
 
 Logger::Logger()

--- a/src/Logger.hpp
+++ b/src/Logger.hpp
@@ -26,8 +26,6 @@
 #include <boost/thread/lock_guard.hpp>
 #include <boost/thread/mutex.hpp>
 
-#include "Defines.h"
-
 /**
  * @class Logger
  * @brief Provides static functions for threadsafe logging.
@@ -35,7 +33,9 @@
 class Logger
 {
 public:
-    DEFAULT_CTOR_DTOR(Logger)
+    Logger();
+
+    ~Logger() noexcept;
 
     /**
      * @fn info

--- a/src/Logger.hpp
+++ b/src/Logger.hpp
@@ -22,6 +22,7 @@
 #pragma once
 
 #include <iostream>
+#include <string>
 #include <boost/thread/lock_guard.hpp>
 #include <boost/thread/mutex.hpp>
 

--- a/src/Parameters.h
+++ b/src/Parameters.h
@@ -63,7 +63,7 @@
  * Consider someone else wants surrounding traffic displayed from
  * somewhere else, like pilots and flight instructors.
  */
-#define SERVER_MAX_CLIENTS 5
+#define SERVER_MAX_CLIENTS 3
 
 /**
  * @def ESTIMATED_TRAFFIC

--- a/src/Signals.cpp
+++ b/src/Signals.cpp
@@ -1,0 +1,61 @@
+/*
+ Copyright_License {
+
+ Copyright (C) 2016 VirtualFlightRadar-Backend
+ A detailed list of copyright holders can be found in the file "AUTHORS".
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License version 3
+ as published by the Free Software Foundation.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program; if not, write to the Free Software
+ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ }
+ */
+
+#include <boost/thread/lock_guard.hpp>
+
+#include "Signals.h"
+
+Signals::Signals() : mIoService(), mSigSet(mIoService)
+{
+    mSigSet.add(SIGINT);
+    mSigSet.add(SIGTERM);
+#ifdef SIGQUIT
+    mSigSet.add(SIGQUIT);
+#endif
+}
+
+Signals::~Signals() noexcept
+{}
+
+void Signals::run()
+{
+    boost::lock_guard<boost::mutex> lock(mMutex);
+    mThread = boost::thread([this]() { mIoService.run(); });
+}
+
+void Signals::stop()
+{
+    boost::lock_guard<boost::mutex> lock(mMutex);
+    if(!mIoService.stopped())
+    {
+        mIoService.stop();
+    }
+    if(mThread.joinable())
+    {
+        mThread.join();
+    }
+}
+
+void Signals::addHandler(const SignalHandler& crHandler)
+{
+    boost::lock_guard<boost::mutex> lock(mMutex);
+    mSigSet.async_wait(crHandler);
+}

--- a/src/Signals.cpp
+++ b/src/Signals.cpp
@@ -43,10 +43,12 @@ void Signals::run()
 
 void Signals::stop()
 {
-    boost::lock_guard<boost::mutex> lock(mMutex);
-    if(!mIoService.stopped())
     {
-        mIoService.stop();
+        boost::lock_guard<boost::mutex> lock(mMutex);
+        if(!mIoService.stopped())
+        {
+            mIoService.stop();
+        }
     }
     if(mThread.joinable())
     {

--- a/src/Signals.h
+++ b/src/Signals.h
@@ -34,7 +34,7 @@ using SignalHandler = std::function<void(const boost::system::error_code&, const
 class Signals
 {
 public:
-    NON_COPYABLE(Signals)
+    NOT_COPYABLE(Signals)
 
     Signals();
     ~Signals() noexcept;

--- a/src/Signals.h
+++ b/src/Signals.h
@@ -1,0 +1,51 @@
+/*
+ Copyright_License {
+
+ Copyright (C) 2016 VirtualFlightRadar-Backend
+ A detailed list of copyright holders can be found in the file "AUTHORS".
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License version 3
+ as published by the Free Software Foundation.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program; if not, write to the Free Software
+ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ }
+ */
+
+#pragma once
+
+#include <functional>
+#include <boost/asio.hpp>
+#include <boost/system/error_code.hpp>
+#include <boost/thread.hpp>
+#include <boost/thread/mutex.hpp>
+
+#include "Defines.h"
+
+using SignalHandler = std::function<void(const boost::system::error_code&, const int)>;
+
+class Signals
+{
+public:
+    NON_COPYABLE(Signals)
+
+    Signals();
+    ~Signals() noexcept;
+
+    void run();
+    void stop();
+    void addHandler(const SignalHandler& crHandler);
+
+private:
+    boost::asio::io_service mIoService;
+    boost::asio::signal_set mSigSet;
+    boost::thread mThread;
+    boost::mutex mMutex;
+};

--- a/src/VFRB.cpp
+++ b/src/VFRB.cpp
@@ -124,9 +124,9 @@ void VFRB::setupSignals(boost::asio::signal_set& rSigSet)
 {
     rSigSet.add(SIGINT);
     rSigSet.add(SIGTERM);
-#if defined(SIGQUIT)
+#ifdef SIGQUIT
     rSigSet.add(SIGQUIT);
-#endif  // defined(SIGQUIT)
+#endif
 
     rSigSet.async_wait([this](const boost::system::error_code&, const int) {
         Logger::info("(VFRB) caught signal: ", "shutdown");

--- a/src/VFRB.cpp
+++ b/src/VFRB.cpp
@@ -76,7 +76,7 @@ void VFRB::run() noexcept
     for(const auto& it : mFeeds)
     {
         Logger::info("(VFRB) run feed: ", it->getName());
-        it->registerClient(mClientManager);
+        it->registerToClient(mClientManager);
     }
     boost::thread_group client_threads;
     mClientManager.run(client_threads, signal_set);

--- a/src/VFRB.cpp
+++ b/src/VFRB.cpp
@@ -76,13 +76,14 @@ void VFRB::run() noexcept
         mServer.run(signal_set);
         vRunStatus = false;
     });
+
     for(const auto& it : mFeeds)
     {
         Logger::info("(VFRB) run feed: ", it->getName());
         it->registerToClient(mClientManager);
     }
 
-    mClientManager.run(signal_set);
+    mClientManager.run();
     boost::thread signal_thread([&io_service]() { io_service.run(); });
     mFeeds.clear();
 

--- a/src/VFRB.cpp
+++ b/src/VFRB.cpp
@@ -24,10 +24,7 @@
 #include <csignal>
 #include <exception>
 #include <sstream>
-#include <string>
-#include <utility>
 #include <boost/asio.hpp>
-#include <boost/system/error_code.hpp>
 #include <boost/thread.hpp>
 
 #include "config/Configuration.h"

--- a/src/VFRB.cpp
+++ b/src/VFRB.cpp
@@ -81,16 +81,15 @@ void VFRB::run() noexcept
         Logger::info("(VFRB) run feed: ", it->getName());
         it->registerToClient(mClientManager);
     }
-    boost::thread_group client_threads;
-    mClientManager.run(client_threads, signal_set);
+
+    mClientManager.run(signal_set);
     boost::thread signal_thread([&io_service]() { io_service.run(); });
     mFeeds.clear();
 
     serve();
-    mClientManager.stop();
 
+    mClientManager.stop();
     server_thread.join();
-    client_threads.join_all();
     signal_thread.join();
 
     Logger::info("Stopped after ", getDuration(start));

--- a/src/VFRB.h
+++ b/src/VFRB.h
@@ -53,7 +53,7 @@ class Feed;
 class VFRB
 {
 public:
-    NON_COPYABLE(VFRB)
+    NOT_COPYABLE(VFRB)
 
     /**
      * @fn VFRB

--- a/src/VFRB.h
+++ b/src/VFRB.h
@@ -26,7 +26,6 @@
 #include <memory>
 #include <boost/chrono.hpp>
 
-#include "feed/client/ClientManager.h"
 #include "server/Server.h"
 #include "Defines.h"
 
@@ -74,10 +73,6 @@ public:
      */
     void run() noexcept;
 
-    /// @var vRunStatus
-    /// Atomic run-status. By this, every component may determine if the VFRB stops.
-    static std::atomic<bool> vRunStatus;
-
 private:
     /**
      * @fn createFeeds
@@ -85,13 +80,6 @@ private:
      * @param crConfig The Configuration
      */
     void createFeeds(const config::Configuration& crConfig);
-
-    /**
-     * @fn setupSignals
-     * @brief Setup the signal set.
-     * @param rSigSet
-     */
-    void setupSignals(boost::asio::signal_set& rSigSet);
 
     /**
      * @fn serve
@@ -127,9 +115,11 @@ private:
     /// Manage clients and sending of data
     server::Server mServer;
 
-    feed::client::ClientManager mClientManager;
-
     /// @var mFeeds
     /// List of all active feeds
     std::list<std::shared_ptr<feed::Feed>> mFeeds;
+
+    /// @var vRunStatus
+    /// Atomic run-status.
+    std::atomic<bool> mRunStatus;
 };

--- a/src/VFRB.h
+++ b/src/VFRB.h
@@ -24,6 +24,7 @@
 #include <atomic>
 #include <list>
 #include <memory>
+#include <string>
 #include <boost/chrono.hpp>
 
 #include "server/Server.h"

--- a/src/VFRB.h
+++ b/src/VFRB.h
@@ -66,7 +66,7 @@ public:
      * @fn ~VFRB
      * @brief Destructor
      */
-    virtual ~VFRB() noexcept;
+    ~VFRB() noexcept;
 
     /**
      * @fn run

--- a/src/config/ConfigReader.h
+++ b/src/config/ConfigReader.h
@@ -27,7 +27,6 @@
 #include <boost/optional.hpp>
 #include <boost/regex.hpp>
 
-#include "../Defines.h"
 #include "PropertyMap.h"
 
 /// @namespace config
@@ -42,7 +41,9 @@ namespace config
 class ConfigReader
 {
 public:
-    DEFAULT_CTOR_DTOR(ConfigReader)
+    ConfigReader();
+
+    ~ConfigReader() noexcept;
 
     /**
      * @fn read

--- a/src/config/Configuration.cpp
+++ b/src/config/Configuration.cpp
@@ -21,11 +21,11 @@
 
 #include "Configuration.h"
 
-#include <limits>
-#include <sstream>
-#include <stdexcept>
 #include <boost/optional.hpp>
 #include <boost/variant.hpp>
+#include <limits>
+#include <stdexcept>
+#include <utility>
 
 #include "../Logger.hpp"
 #include "ConfigReader.h"

--- a/src/config/Configuration.cpp
+++ b/src/config/Configuration.cpp
@@ -21,11 +21,11 @@
 
 #include "Configuration.h"
 
-#include <boost/optional.hpp>
-#include <boost/variant.hpp>
 #include <limits>
 #include <stdexcept>
 #include <utility>
+#include <boost/optional.hpp>
+#include <boost/variant.hpp>
 
 #include "../Logger.hpp"
 #include "ConfigReader.h"

--- a/src/config/Configuration.h
+++ b/src/config/Configuration.h
@@ -23,8 +23,8 @@
 
 #include <cstdint>
 #include <istream>
+#include <list>
 #include <string>
-#include <utility>
 
 #include "../Defines.h"
 #include "../object/GpsPosition.h"

--- a/src/config/Configuration.h
+++ b/src/config/Configuration.h
@@ -134,7 +134,7 @@ public:
      * @fn ~Configuration
      * @brief Destructor
      */
-    virtual ~Configuration() noexcept;
+    ~Configuration() noexcept;
 
     /**
      * Define and declare getters.

--- a/src/config/Configuration.h
+++ b/src/config/Configuration.h
@@ -56,7 +56,7 @@
 #define SECT_KEY_WIND "wind"
 
 /// @def SECT_KEY_ATMOS
-#define SECT_KEY_ATMOS "atmos"
+#define SECT_KEY_ATMOS "atm"
 
 /**
  * Per section key-value keys

--- a/src/config/PropertyMap.h
+++ b/src/config/PropertyMap.h
@@ -23,7 +23,6 @@
 
 #include <string>
 #include <unordered_map>
-#include <utility>
 
 #include "../Defines.h"
 

--- a/src/config/PropertyMap.h
+++ b/src/config/PropertyMap.h
@@ -24,7 +24,6 @@
 #include <string>
 #include <unordered_map>
 
-#include "../Defines.h"
 
 /// @namespace config
 namespace config
@@ -44,7 +43,9 @@ using KeyValue = std::pair<std::string, std::string>;
 class PropertyMap
 {
 public:
-    DEFAULT_CTOR_DTOR(PropertyMap)
+    PropertyMap();
+
+    ~PropertyMap() noexcept;
 
     /**
      * @fn getProperty

--- a/src/data/AircraftData.cpp
+++ b/src/data/AircraftData.cpp
@@ -21,10 +21,8 @@
 
 #include "AircraftData.h"
 
-#include <algorithm>
 #include <iterator>
 #include <stdexcept>
-#include <system_error>
 #include <boost/thread/lock_guard.hpp>
 
 #include "../Parameters.h"

--- a/src/data/AircraftData.cpp
+++ b/src/data/AircraftData.cpp
@@ -54,7 +54,7 @@ std::string AircraftData::getSerialized()
     boost::lock_guard<boost::mutex> lock(mMutex);
     std::string tmp;
     tmp.reserve(mContainer.size() * 128);
-    for(auto& it : mContainer)
+    for(const auto& it : mContainer)
     {
         tmp += it.getUpdateAge() < OBJ_OUTDATED ? it.getSerialized() : "";
     }
@@ -65,7 +65,7 @@ bool AircraftData::update(Object&& rvAircraft)
 {
     boost::lock_guard<boost::mutex> lock(this->mMutex);
     Aircraft&& rvUpdate = static_cast<Aircraft&&>(rvAircraft);
-    const auto& index   = mIndexMap.find(rvUpdate.getId());
+    const auto index    = mIndexMap.find(rvUpdate.getId());
 
     if(index != mIndexMap.end())
     {

--- a/src/data/AircraftData.h
+++ b/src/data/AircraftData.h
@@ -25,14 +25,12 @@
 #include <cstdint>
 #include <string>
 #include <unordered_map>
-#include <utility>
 #include <vector>
 
 #include "../Defines.h"
 #include "../object/Aircraft.h"
-#include "processor/AircraftProcessor.h"
-
 #include "Data.h"
+#include "processor/AircraftProcessor.h"
 
 ///  @def AC_DELETE_THRESHOLD
 /// Times until aircraft gets deleted

--- a/src/data/AircraftData.h
+++ b/src/data/AircraftData.h
@@ -34,17 +34,13 @@
 
 #include "Data.h"
 
-/// @def AC_OUTDATED
-/// Times until aircraft is outdated
-#define AC_OUTDATED 4
-
 ///  @def AC_DELETE_THRESHOLD
 /// Times until aircraft gets deleted
 #define AC_DELETE_THRESHOLD 120
 
 /// @def AC_NO_FLARM_THRESHOLD
 /// Times until FLARM status is removed
-#define AC_NO_FLARM_THRESHOLD AC_OUTDATED
+#define AC_NO_FLARM_THRESHOLD OBJ_OUTDATED
 
 /// @namespace data
 namespace data
@@ -83,12 +79,7 @@ public:
      * @return true on success, else false
      * @threadsafe
      */
-    bool update(object::Object&& rvAircraft, std::size_t vSlot) override;
-
-    /**
-     * @see Data#registerSlot
-     */
-    std::size_t registerSlot() override;
+    bool update(object::Object&& rvAircraft) override;
 
     /**
      * @fn processAircrafts
@@ -117,11 +108,7 @@ private:
 
     /// @var mIndexMap
     /// Map aircraft Id's to index and attempt counters.
-    std::unordered_map<std::string, std::pair<std::size_t, std::vector<std::uint32_t>>> mIndexMap;
-
-    /// @var mNrOfRegisteredFeeds
-    /// The number of registered Feeds
-    std::size_t mNrOfRegisteredFeeds = 0;
+    std::unordered_map<std::string, std::size_t> mIndexMap;
 };
 
 }  // namespace data

--- a/src/data/AircraftData.h
+++ b/src/data/AircraftData.h
@@ -29,8 +29,8 @@
 
 #include "../Defines.h"
 #include "../object/Aircraft.h"
-#include "Data.h"
 #include "processor/AircraftProcessor.h"
+#include "Data.h"
 
 ///  @def AC_DELETE_THRESHOLD
 /// Times until aircraft gets deleted

--- a/src/data/AircraftData.h
+++ b/src/data/AircraftData.h
@@ -27,7 +27,6 @@
 #include <unordered_map>
 #include <vector>
 
-#include "../Defines.h"
 #include "../object/Aircraft.h"
 #include "processor/AircraftProcessor.h"
 #include "Data.h"
@@ -51,7 +50,7 @@ namespace data
 class AircraftData : public Data
 {
 public:
-    DEFAULT_CTOR_DTOR(AircraftData)
+    AircraftData();
 
     /**
      * @fn AircraftData
@@ -59,6 +58,8 @@ public:
      * @param vMaxDist The max distance filter
      */
     explicit AircraftData(std::int32_t vMaxDist);
+
+    ~AircraftData() noexcept;
 
     /**
      * @fn getSerialized

--- a/src/data/AtmosphereData.cpp
+++ b/src/data/AtmosphereData.cpp
@@ -21,8 +21,6 @@
 
 #include "AtmosphereData.h"
 
-#include <algorithm>
-#include <stdexcept>
 #include <boost/thread/lock_guard.hpp>
 
 using namespace object;

--- a/src/data/AtmosphereData.cpp
+++ b/src/data/AtmosphereData.cpp
@@ -41,31 +41,13 @@ AtmosphereData::~AtmosphereData() noexcept
 std::string AtmosphereData::getSerialized()
 {
     boost::lock_guard<boost::mutex> lock(mMutex);
-    return mAtmosphere.getSerialized();
+    return (++mAtmosphere).getSerialized();
 }
 
-bool AtmosphereData::update(Object&& rvAtmosphere, std::size_t vSlot)
+bool AtmosphereData::update(Object&& rvAtmosphere)
 {
     boost::lock_guard<boost::mutex> lock(mMutex);
-    try
-    {
-        bool updated = mAtmosphere.tryUpdate(std::move(rvAtmosphere), ++mAttempts.at(vSlot));
-        if(updated)
-        {
-            std::fill(mAttempts.begin(), mAttempts.end(), 0);
-        }
-        return updated;
-    }
-    catch(const std::out_of_range&)
-    {
-        return false;
-    }
-}
-
-std::size_t AtmosphereData::registerSlot()
-{
-    mAttempts.push_back(0);
-    return mAttempts.size() - 1;
+    return mAtmosphere.tryUpdate(std::move(rvAtmosphere));
 }
 
 double AtmosphereData::getAtmPressure()

--- a/src/data/AtmosphereData.h
+++ b/src/data/AtmosphereData.h
@@ -23,7 +23,6 @@
 
 #include <string>
 
-#include "../Defines.h"
 #include "../object/Atmosphere.h"
 #include "Data.h"
 
@@ -38,7 +37,7 @@ namespace data
 class AtmosphereData : public Data
 {
 public:
-    DEFAULT_CTOR_DTOR(AtmosphereData)
+    AtmosphereData();
 
     /**
      * @fn AtmosphereData
@@ -46,6 +45,8 @@ public:
      * @param vAtmosphere The initial info
      */
     explicit AtmosphereData(const object::Atmosphere& crAtmosphere);
+
+    ~AtmosphereData() noexcept;
 
     /**
      * @fn getSerialized

--- a/src/data/AtmosphereData.h
+++ b/src/data/AtmosphereData.h
@@ -21,14 +21,10 @@
 
 #pragma once
 
-#include <cstddef>
-#include <cstdint>
 #include <string>
-#include <vector>
 
 #include "../Defines.h"
 #include "../object/Atmosphere.h"
-
 #include "Data.h"
 
 /// @namespace data

--- a/src/data/AtmosphereData.h
+++ b/src/data/AtmosphereData.h
@@ -67,12 +67,7 @@ public:
      * @return true on success, else false
      * @threadsafe
      */
-    bool update(object::Object&& rvAtmosphere, std::size_t vSlot) override;
-
-    /**
-     * @see Data#registerSlot
-     */
-    std::size_t registerSlot() override;
+    bool update(object::Object&& rvAtmosphere) override;
 
     /**
      * @fn getAtmPressure
@@ -86,9 +81,5 @@ private:
     /// @var mAtmosphere
     /// Holding atmospheric information
     object::Atmosphere mAtmosphere;
-
-    /// @var mAttempts
-    /// Store update attempts per Feed
-    std::vector<std::uint32_t> mAttempts;
 };
 }  // namespace data

--- a/src/data/Data.h
+++ b/src/data/Data.h
@@ -55,14 +55,7 @@ public:
      * @param vSlot The slot for registered attempts
      * @return true on success, else false
      */
-    virtual bool update(object::Object&& _1, std::size_t vSlot) = 0;
-
-    /**
-     * @fn registerSlot
-     * @brief Register an attempt slot.
-     * @return the slot number
-     */
-    virtual std::size_t registerSlot() = 0;
+    virtual bool update(object::Object&& _1) = 0;
 
 protected:
     /// @var mMutex

--- a/src/data/Data.h
+++ b/src/data/Data.h
@@ -20,8 +20,6 @@
 #include <string>
 #include <boost/thread/mutex.hpp>
 
-#include "../Defines.h"
-
 /// @namespace object
 namespace object
 {
@@ -38,7 +36,9 @@ namespace data
 class Data
 {
 public:
-    DEFAULT_CTOR_DTOR(Data)
+    Data();
+
+    virtual ~Data() noexcept;
 
     /**
      * @fn getSerialized

--- a/src/data/Data.h
+++ b/src/data/Data.h
@@ -17,7 +17,6 @@
 
 #pragma once
 
-#include <cstddef>
 #include <string>
 #include <boost/thread/mutex.hpp>
 

--- a/src/data/GpsData.cpp
+++ b/src/data/GpsData.cpp
@@ -56,36 +56,22 @@ GpsData::~GpsData() noexcept
 std::string GpsData::getSerialized()
 {
     boost::lock_guard<boost::mutex> lock(mMutex);
-    return mPosition.getSerialized();
+    return (++mPosition).getSerialized();
 }
 
-bool GpsData::update(Object&& rvPosition, std::size_t vSlot)
+bool GpsData::update(Object&& rvPosition)
 {
     boost::lock_guard<boost::mutex> lock(mMutex);
     if(mPositionLocked)
     {
         throw std::runtime_error("Position was locked before.");
     }
-    try
+    bool updated = mPosition.tryUpdate(std::move(rvPosition));
+    if(updated)
     {
-        bool updated = mPosition.tryUpdate(std::move(rvPosition), ++mAttempts.at(vSlot));
-        if(updated)
-        {
-            std::fill(mAttempts.begin(), mAttempts.end(), 0);
-            mProcessor.process(mPosition);
-        }
-        return (mPositionLocked = updated && mGroundMode && isPositionGood());
+        mProcessor.process(mPosition);
     }
-    catch(const std::out_of_range&)
-    {
-        return false;
-    }
-}
-
-std::size_t GpsData::registerSlot()
-{
-    mAttempts.push_back(0);
-    return mAttempts.size() - 1;
+    return (mPositionLocked = updated && mGroundMode && isPositionGood());
 }
 
 Position GpsData::getPosition()

--- a/src/data/GpsData.cpp
+++ b/src/data/GpsData.cpp
@@ -21,7 +21,6 @@
 
 #include "GpsData.h"
 
-#include <algorithm>
 #include <stdexcept>
 #include <boost/thread/lock_guard.hpp>
 

--- a/src/data/GpsData.h
+++ b/src/data/GpsData.h
@@ -23,7 +23,6 @@
 
 #include <string>
 
-#include "../Defines.h"
 #include "../object/GpsPosition.h"
 #include "processor/GpsProcessor.h"
 #include "Data.h"
@@ -39,7 +38,7 @@ namespace data
 class GpsData : public Data
 {
 public:
-    DEFAULT_CTOR_DTOR(GpsData)
+    GpsData();
 
     /**
      * @fn GpsData
@@ -47,6 +46,8 @@ public:
      * @param crPosition The initial info
      */
     GpsData(const object::GpsPosition& crPosition, bool vGround);
+
+    ~GpsData() noexcept;
 
     /**
      * @fn getSerialized

--- a/src/data/GpsData.h
+++ b/src/data/GpsData.h
@@ -25,8 +25,8 @@
 
 #include "../Defines.h"
 #include "../object/GpsPosition.h"
-#include "Data.h"
 #include "processor/GpsProcessor.h"
+#include "Data.h"
 
 /// @namespace data
 namespace data

--- a/src/data/GpsData.h
+++ b/src/data/GpsData.h
@@ -21,16 +21,12 @@
 
 #pragma once
 
-#include <cstddef>
-#include <cstdint>
 #include <string>
-#include <vector>
 
 #include "../Defines.h"
 #include "../object/GpsPosition.h"
-#include "processor/GpsProcessor.h"
-
 #include "Data.h"
+#include "processor/GpsProcessor.h"
 
 /// @namespace data
 namespace data

--- a/src/data/GpsData.h
+++ b/src/data/GpsData.h
@@ -50,7 +50,7 @@ public:
      * @brief Constructor
      * @param crPosition The initial info
      */
-    explicit GpsData(const object::GpsPosition& crPosition, bool vGround);
+    GpsData(const object::GpsPosition& crPosition, bool vGround);
 
     /**
      * @fn getSerialized
@@ -76,12 +76,7 @@ public:
      * @return true on success, else false
      * @threadsafe
      */
-    bool update(object::Object&& rvPosition, std::size_t vSlot) override;
-
-    /**
-     * @see Data#registerSlot
-     */
-    std::size_t registerSlot() override;
+    bool update(object::Object&& rvPosition) override;
 
 private:
     /**
@@ -106,10 +101,6 @@ private:
     /// @var mGroundMode
     /// Ground mode state
     bool mGroundMode = false;
-
-    /// @var mAttempts
-    /// Store update attempts
-    std::vector<std::uint32_t> mAttempts;
 };
 
 }  // namespace data

--- a/src/data/WindData.cpp
+++ b/src/data/WindData.cpp
@@ -41,33 +41,15 @@ WindData::~WindData() noexcept
 std::string WindData::getSerialized()
 {
     boost::lock_guard<boost::mutex> lock(mMutex);
-    std::string tmp(mWind.getSerialized());
+    std::string tmp((++mWind).getSerialized());
     mWind.setSerialized("");
     return tmp;
 }
 
-bool WindData::update(Object&& rvWind, std::size_t vSlot)
+bool WindData::update(Object&& rvWind)
 {
     boost::lock_guard<boost::mutex> lock(mMutex);
-    try
-    {
-        bool updated = mWind.tryUpdate(std::move(rvWind), ++mAttempts.at(vSlot));
-        if(updated)
-        {
-            std::fill(mAttempts.begin(), mAttempts.end(), 0);
-        }
-        return updated;
-    }
-    catch(const std::out_of_range&)
-    {
-        return false;
-    }
-}
-
-std::size_t WindData::registerSlot()
-{
-    mAttempts.push_back(0);
-    return mAttempts.size() - 1;
+    return mWind.tryUpdate(std::move(rvWind));
 }
 
 }  // namespace data

--- a/src/data/WindData.cpp
+++ b/src/data/WindData.cpp
@@ -21,8 +21,6 @@
 
 #include "WindData.h"
 
-#include <algorithm>
-#include <stdexcept>
 #include <boost/thread/lock_guard.hpp>
 
 using namespace object;

--- a/src/data/WindData.h
+++ b/src/data/WindData.h
@@ -21,14 +21,10 @@
 
 #pragma once
 
-#include <cstddef>
-#include <cstdint>
 #include <string>
-#include <vector>
 
 #include "../Defines.h"
 #include "../object/Wind.h"
-
 #include "Data.h"
 
 /// @namespace data

--- a/src/data/WindData.h
+++ b/src/data/WindData.h
@@ -68,21 +68,12 @@ public:
      * @return true on success, else false
      * @threadsafe
      */
-    bool update(object::Object&& rvWind, std::size_t vSlot) override;
-
-    /**
-     * @see Data#registerSlot
-     */
-    std::size_t registerSlot() override;
+    bool update(object::Object&& rvWind) override;
 
 private:
     /// @var mWind
     /// The Wind information
     object::Wind mWind;
-
-    /// @var mAttempts
-    /// Store update attempts
-    std::vector<std::uint32_t> mAttempts;
 };
 
 }  // namespace data

--- a/src/data/WindData.h
+++ b/src/data/WindData.h
@@ -23,7 +23,6 @@
 
 #include <string>
 
-#include "../Defines.h"
 #include "../object/Wind.h"
 #include "Data.h"
 
@@ -38,7 +37,7 @@ namespace data
 class WindData : public Data
 {
 public:
-    DEFAULT_CTOR_DTOR(WindData)
+    WindData();
 
     /**
      * @fn WindData
@@ -46,6 +45,8 @@ public:
      * @param crWind The initial wind information
      */
     explicit WindData(const object::Wind& crWind);
+
+    ~WindData() noexcept;
 
     /**
      * @fn getSerialized

--- a/src/data/processor/AircraftProcessor.h
+++ b/src/data/processor/AircraftProcessor.h
@@ -27,7 +27,6 @@
 #include "../../Defines.h"
 #include "../../object/Aircraft.h"
 #include "../../object/GpsPosition.h"
-
 #include "Processor.hpp"
 
 /// @namespace data

--- a/src/data/processor/AircraftProcessor.h
+++ b/src/data/processor/AircraftProcessor.h
@@ -24,9 +24,9 @@
 #include <cstdint>
 #include <string>
 
-#include "../../Defines.h"
 #include "../../object/Aircraft.h"
 #include "../../object/GpsPosition.h"
+
 #include "Processor.hpp"
 
 /// @namespace data
@@ -43,7 +43,7 @@ namespace processor
 class AircraftProcessor : public Processor<object::Aircraft>
 {
 public:
-    DEFAULT_CTOR_DTOR(AircraftProcessor)
+    AircraftProcessor();
 
     /**
      * @fn AircraftProcessor
@@ -51,6 +51,8 @@ public:
      * @param vMaxDist The max distance filter
      */
     explicit AircraftProcessor(std::int32_t vMaxDist);
+
+    ~AircraftProcessor() noexcept;
 
     /**
      * @fn process

--- a/src/data/processor/GpsProcessor.cpp
+++ b/src/data/processor/GpsProcessor.cpp
@@ -21,6 +21,8 @@
 
 #include "GpsProcessor.h"
 
+#include <cmath>
+#include <cstdio>
 #include <ctime>
 
 using namespace object;

--- a/src/data/processor/GpsProcessor.h
+++ b/src/data/processor/GpsProcessor.h
@@ -23,7 +23,6 @@
 
 #include <string>
 
-#include "../../Defines.h"
 #include "../../object/GpsPosition.h"
 
 #include "Processor.hpp"
@@ -41,7 +40,9 @@ namespace processor
 class GpsProcessor : public Processor<object::GpsPosition>
 {
 public:
-    DEFAULT_CTOR_DTOR(GpsProcessor)
+    GpsProcessor();
+
+    ~GpsProcessor() noexcept;
 
     /**
      * @fn process

--- a/src/data/processor/Processor.hpp
+++ b/src/data/processor/Processor.hpp
@@ -24,7 +24,6 @@
 #include <cstdio>
 #include <string>
 
-#include "../../Defines.h"
 #include "../../Math.hpp"
 
 /// @def PROC_BUFF_S
@@ -46,7 +45,11 @@ template<typename T>
 class Processor
 {
 public:
-    DEFAULT_CTOR_DTOR_INLINE(Processor)
+    Processor()
+    {}
+
+    virtual ~Processor() noexcept
+    {}
 
     /**
      * @fn process

--- a/src/feed/AprscFeed.cpp
+++ b/src/feed/AprscFeed.cpp
@@ -23,13 +23,13 @@
 
 #include <stdexcept>
 
-#include "../config/Configuration.h"
 #include "../Logger.hpp"
+#include "../config/Configuration.h"
+#include "../data/AircraftData.h"
 #include "../object/Aircraft.h"
 #include "client/Client.h"
 #include "client/ClientManager.h"
 #include "parser/AprsParser.h"
-#include "../data/AircraftData.h"
 
 #ifdef COMPONENT
 #undef COMPONENT

--- a/src/feed/AprscFeed.cpp
+++ b/src/feed/AprscFeed.cpp
@@ -58,7 +58,7 @@ AprscFeed::~AprscFeed() noexcept
     Logger::debug(mName, " destructed ", COMPONENT);
 }
 
-void AprscFeed::registerClient(client::ClientManager& rManager)
+void AprscFeed::registerToClient(client::ClientManager& rManager)
 {
     mSubsribedClient = rManager.subscribe(
         shared_from_this(), {mKvMap.find(KV_KEY_HOST)->second, mKvMap.find(KV_KEY_PORT)->second},
@@ -71,7 +71,7 @@ void AprscFeed::process(const std::string& crResponse) noexcept
     object::Aircraft ac(getPriority());
     if(smParser.unpack(crResponse, ac))
     {
-        mpData->update(std::move(ac), mDataSlot);
+        mpData->update(std::move(ac));
     }
 }
 

--- a/src/feed/AprscFeed.cpp
+++ b/src/feed/AprscFeed.cpp
@@ -22,13 +22,14 @@
 #include "AprscFeed.h"
 
 #include <stdexcept>
-#include <unordered_map>
 
-#include "../Logger.hpp"
 #include "../config/Configuration.h"
-#include "../data/AircraftData.h"
+#include "../Logger.hpp"
 #include "../object/Aircraft.h"
+#include "client/Client.h"
 #include "client/ClientManager.h"
+#include "parser/AprsParser.h"
+#include "../data/AircraftData.h"
 
 #ifdef COMPONENT
 #undef COMPONENT
@@ -40,7 +41,7 @@ namespace feed
 parser::AprsParser AprscFeed::smParser;
 
 AprscFeed::AprscFeed(const std::string& crName, const config::KeyValueMap& crKvMap,
-                     std::shared_ptr<data::AircraftData>& pData, std::int32_t vMaxHeight)
+                     std::shared_ptr<data::AircraftData> pData, std::int32_t vMaxHeight)
     : Feed(crName, crKvMap, pData)
 {
     Logger::debug(crName, " constructed ", COMPONENT);

--- a/src/feed/AprscFeed.cpp
+++ b/src/feed/AprscFeed.cpp
@@ -44,7 +44,6 @@ AprscFeed::AprscFeed(const std::string& crName, const config::KeyValueMap& crKvM
                      std::shared_ptr<data::AircraftData> pData, std::int32_t vMaxHeight)
     : Feed(crName, crKvMap, pData)
 {
-    Logger::debug(crName, " constructed ", COMPONENT);
     smParser.setMaxHeight(vMaxHeight);
     mLoginStrIt = mKvMap.find(KV_KEY_LOGIN);
     if(mLoginStrIt == mKvMap.end())
@@ -55,9 +54,7 @@ AprscFeed::AprscFeed(const std::string& crName, const config::KeyValueMap& crKvM
 }
 
 AprscFeed::~AprscFeed() noexcept
-{
-    Logger::debug(mName, " destructed ", COMPONENT);
-}
+{}
 
 void AprscFeed::registerToClient(client::ClientManager& rManager)
 {
@@ -68,7 +65,6 @@ void AprscFeed::registerToClient(client::ClientManager& rManager)
 
 void AprscFeed::process(const std::string& crResponse) noexcept
 {
-    Logger::debug(mName, " process called");
     object::Aircraft ac(getPriority());
     if(smParser.unpack(crResponse, ac))
     {

--- a/src/feed/AprscFeed.h
+++ b/src/feed/AprscFeed.h
@@ -26,12 +26,14 @@
 #include <string>
 #include <unordered_map>
 
-#include "../config/PropertyMap.h"
 #include "../Defines.h"
+#include "../config/PropertyMap.h"
 #include "Feed.h"
 
-namespace feed {
-namespace parser {
+namespace feed
+{
+namespace parser
+{
 class AprsParser;
 } /* namespace parser */
 } /* namespace feed */

--- a/src/feed/AprscFeed.h
+++ b/src/feed/AprscFeed.h
@@ -73,7 +73,7 @@ public:
      * @fn ~AprscFeed
      * @brief Destructor
      */
-    virtual ~AprscFeed() noexcept;
+    ~AprscFeed() noexcept;
 
     void registerToClient(client::ClientManager& rManager) override;
 

--- a/src/feed/AprscFeed.h
+++ b/src/feed/AprscFeed.h
@@ -21,16 +21,20 @@
 
 #pragma once
 
-#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
-#include "../Defines.h"
 #include "../config/PropertyMap.h"
-#include "parser/AprsParser.h"
-
+#include "../Defines.h"
 #include "Feed.h"
+
+namespace feed {
+namespace parser {
+class AprsParser;
+} /* namespace parser */
+} /* namespace feed */
 
 /// @namespace data
 namespace data
@@ -61,7 +65,7 @@ public:
      * @throw std::logic_error if login is not given or from parent constructor
      */
     AprscFeed(const std::string& crName, const config::KeyValueMap& crKvMap,
-              std::shared_ptr<data::AircraftData>& pData, std::int32_t vMaxHeight);
+              std::shared_ptr<data::AircraftData> pData, std::int32_t vMaxHeight);
 
     /**
      * @fn ~AprscFeed

--- a/src/feed/AprscFeed.h
+++ b/src/feed/AprscFeed.h
@@ -55,7 +55,7 @@ namespace feed
 class AprscFeed : public Feed, public std::enable_shared_from_this<AprscFeed>
 {
 public:
-    NON_COPYABLE(AprscFeed)
+    NOT_COPYABLE(AprscFeed)
 
     /**
      * @fn AprscFeed

--- a/src/feed/AprscFeed.h
+++ b/src/feed/AprscFeed.h
@@ -69,7 +69,7 @@ public:
      */
     virtual ~AprscFeed() noexcept;
 
-    void registerClient(client::ClientManager& rManager) override;
+    void registerToClient(client::ClientManager& rManager) override;
 
     /**
      * @see Feed#process

--- a/src/feed/AtmosphereFeed.cpp
+++ b/src/feed/AtmosphereFeed.cpp
@@ -40,7 +40,7 @@ AtmosphereFeed::AtmosphereFeed(const std::string& crName, const config::KeyValue
 AtmosphereFeed::~AtmosphereFeed() noexcept
 {}
 
-void AtmosphereFeed::registerClient(client::ClientManager& rManager)
+void AtmosphereFeed::registerToClient(client::ClientManager& rManager)
 {
     mSubsribedClient = rManager.subscribe(
         shared_from_this(), {mKvMap.find(KV_KEY_HOST)->second, mKvMap.find(KV_KEY_PORT)->second},
@@ -52,7 +52,7 @@ void AtmosphereFeed::process(const std::string& crResponse) noexcept
     object::Atmosphere atmos(getPriority());
     if(smParser.unpack(crResponse, atmos))
     {
-        mpData->update(std::move(atmos), mDataSlot);
+        mpData->update(std::move(atmos));
     }
 }
 

--- a/src/feed/AtmosphereFeed.cpp
+++ b/src/feed/AtmosphereFeed.cpp
@@ -25,15 +25,17 @@
 
 #include "../config/Configuration.h"
 #include "../data/AtmosphereData.h"
-#include "../data/WindData.h"
 #include "../object/Atmosphere.h"
+#include "client/Client.h"
+#include "client/ClientManager.h"
+#include "parser/AtmosphereParser.h"
 
 namespace feed
 {
 parser::AtmosphereParser AtmosphereFeed::smParser;
 
 AtmosphereFeed::AtmosphereFeed(const std::string& crName, const config::KeyValueMap& crKvMap,
-                               std::shared_ptr<data::AtmosphereData>& pData)
+                               std::shared_ptr<data::AtmosphereData> pData)
     : Feed(crName, crKvMap, pData)
 {}
 

--- a/src/feed/AtmosphereFeed.h
+++ b/src/feed/AtmosphereFeed.h
@@ -53,7 +53,7 @@ namespace feed
 class AtmosphereFeed : public Feed, public std::enable_shared_from_this<AtmosphereFeed>
 {
 public:
-    NON_COPYABLE(AtmosphereFeed)
+    NOT_COPYABLE(AtmosphereFeed)
 
     /**
      * @fn AtmosphereFeed

--- a/src/feed/AtmosphereFeed.h
+++ b/src/feed/AtmosphereFeed.h
@@ -71,7 +71,7 @@ public:
      * @fn ~AtmosphereFeed
      * @brief Destructor
      */
-    virtual ~AtmosphereFeed() noexcept;
+    ~AtmosphereFeed() noexcept;
 
     void registerToClient(client::ClientManager& rManager) override;
 

--- a/src/feed/AtmosphereFeed.h
+++ b/src/feed/AtmosphereFeed.h
@@ -24,12 +24,14 @@
 #include <memory>
 #include <string>
 
-#include "../config/PropertyMap.h"
 #include "../Defines.h"
+#include "../config/PropertyMap.h"
 #include "Feed.h"
 
-namespace feed {
-namespace parser {
+namespace feed
+{
+namespace parser
+{
 class AtmosphereParser;
 } /* namespace parser */
 } /* namespace feed */

--- a/src/feed/AtmosphereFeed.h
+++ b/src/feed/AtmosphereFeed.h
@@ -68,7 +68,7 @@ public:
      */
     virtual ~AtmosphereFeed() noexcept;
 
-    void registerClient(client::ClientManager& rManager) override;
+    void registerToClient(client::ClientManager& rManager) override;
 
     /**
      * @see Feed#process

--- a/src/feed/AtmosphereFeed.h
+++ b/src/feed/AtmosphereFeed.h
@@ -21,15 +21,18 @@
 
 #pragma once
 
-#include <cstddef>
 #include <memory>
 #include <string>
 
-#include "../Defines.h"
 #include "../config/PropertyMap.h"
-#include "parser/AtmosphereParser.h"
-
+#include "../Defines.h"
 #include "Feed.h"
+
+namespace feed {
+namespace parser {
+class AtmosphereParser;
+} /* namespace parser */
+} /* namespace feed */
 
 /// @namespace data
 namespace data
@@ -60,7 +63,7 @@ public:
      * @throw std::logic_error from parent constructor
      */
     AtmosphereFeed(const std::string& crName, const config::KeyValueMap& crKvMap,
-                   std::shared_ptr<data::AtmosphereData>& pData);
+                   std::shared_ptr<data::AtmosphereData> pData);
 
     /**
      * @fn ~AtmosphereFeed

--- a/src/feed/Feed.cpp
+++ b/src/feed/Feed.cpp
@@ -41,7 +41,6 @@ Feed::Feed(const std::string& crName, const config::KeyValueMap& crKvMap,
            std::shared_ptr<data::Data> pData)
     : mName(crName), mKvMap(crKvMap), mpData(pData)
 {
-    Logger::debug(crName, " constructed ", COMPONENT);
     initPriority();
     if(mKvMap.find(KV_KEY_HOST) == mKvMap.end())
     {
@@ -56,9 +55,7 @@ Feed::Feed(const std::string& crName, const config::KeyValueMap& crKvMap,
 }
 
 Feed::~Feed() noexcept
-{
-    Logger::debug(mName, " destructed ", COMPONENT);
-}
+{}
 
 void Feed::initPriority() noexcept
 {

--- a/src/feed/Feed.cpp
+++ b/src/feed/Feed.cpp
@@ -22,14 +22,13 @@
 #include "Feed.h"
 
 #include <algorithm>
-#include <atomic>
 #include <limits>
 #include <stdexcept>
 #include <unordered_map>
 
-#include "../Logger.hpp"
 #include "../config/Configuration.h"
-#include "client/Client.h"
+#include "../Logger.hpp"
+#include "../data/Data.h"
 
 #ifdef COMPONENT
 #undef COMPONENT

--- a/src/feed/Feed.cpp
+++ b/src/feed/Feed.cpp
@@ -26,8 +26,8 @@
 #include <stdexcept>
 #include <unordered_map>
 
-#include "../config/Configuration.h"
 #include "../Logger.hpp"
+#include "../config/Configuration.h"
 #include "../data/Data.h"
 
 #ifdef COMPONENT

--- a/src/feed/Feed.cpp
+++ b/src/feed/Feed.cpp
@@ -54,7 +54,6 @@ Feed::Feed(const std::string& crName, const config::KeyValueMap& crKvMap,
         Logger::warn(COMPONENT " could not find: ", mName, "." KV_KEY_PORT);
         throw std::logic_error("No port given");
     }
-    mDataSlot = mpData->registerSlot();
 }
 
 Feed::~Feed() noexcept

--- a/src/feed/Feed.h
+++ b/src/feed/Feed.h
@@ -25,10 +25,18 @@
 #include <memory>
 #include <string>
 
-#include "../Defines.h"
 #include "../config/PropertyMap.h"
-#include "../data/Data.h"
-#include "client/ClientManager.h"
+#include "../Defines.h"
+
+namespace data {
+class Data;
+} /* namespace data */
+namespace feed {
+namespace client {
+class Client;
+class ClientManager;
+} /* namespace client */
+} /* namespace feed */
 
 /// @namespace feed
 namespace feed

--- a/src/feed/Feed.h
+++ b/src/feed/Feed.h
@@ -51,7 +51,7 @@ namespace feed
 class Feed
 {
 public:
-    NON_COPYABLE(Feed)
+    NOT_COPYABLE(Feed)
 
     /**
      * @fn ~Feed

--- a/src/feed/Feed.h
+++ b/src/feed/Feed.h
@@ -25,14 +25,17 @@
 #include <memory>
 #include <string>
 
-#include "../config/PropertyMap.h"
 #include "../Defines.h"
+#include "../config/PropertyMap.h"
 
-namespace data {
+namespace data
+{
 class Data;
 } /* namespace data */
-namespace feed {
-namespace client {
+namespace feed
+{
+namespace client
+{
 class Client;
 class ClientManager;
 } /* namespace client */

--- a/src/feed/Feed.h
+++ b/src/feed/Feed.h
@@ -48,7 +48,7 @@ public:
      */
     virtual ~Feed() noexcept;
 
-    virtual void registerClient(client::ClientManager& rManager) = 0;
+    virtual void registerToClient(client::ClientManager& rManager) = 0;
 
     /**
      * @fn process
@@ -83,10 +83,6 @@ protected:
     const config::KeyValueMap mKvMap;
 
     std::weak_ptr<client::Client> mSubsribedClient;
-
-    /// @var mAtmosSlot
-    /// AtmosphereData attempt slot
-    std::size_t mDataSlot;
 
     std::shared_ptr<data::Data> mpData;
 

--- a/src/feed/FeedFactory.cpp
+++ b/src/feed/FeedFactory.cpp
@@ -21,6 +21,7 @@
 
 #include "FeedFactory.h"
 
+#include "../config/Configuration.h"
 #include "../data/AircraftData.h"
 #include "../data/AtmosphereData.h"
 #include "../data/GpsData.h"

--- a/src/feed/FeedFactory.h
+++ b/src/feed/FeedFactory.h
@@ -23,6 +23,7 @@
 
 #include <memory>
 #include <string>
+#include <type_traits>
 #include <boost/optional.hpp>
 
 #include "../config/PropertyMap.h"
@@ -71,7 +72,7 @@ public:
      * @fn ~FeedFactory
      * @brief Destructor
      */
-    virtual ~FeedFactory() noexcept;
+    ~FeedFactory() noexcept;
 
     /**
      * @fn createFeed
@@ -95,7 +96,7 @@ private:
      * @return a pointer to the concrete Feed
      * @throw std::logic_error from invoked constructors
      */
-    template<typename T>
+    template<typename T, typename std::enable_if<std::is_base_of<Feed, T>::value>::type* = nullptr>
     std::shared_ptr<T> makeFeed(const std::string& crName, const config::KeyValueMap& crKvMap);
 
     /// @var mrConfig

--- a/src/feed/FeedFactory.h
+++ b/src/feed/FeedFactory.h
@@ -21,13 +21,14 @@
 
 #pragma once
 
-#include <boost/optional.hpp>
 #include <memory>
 #include <string>
+#include <boost/optional.hpp>
 
 #include "../config/PropertyMap.h"
 
-namespace config {
+namespace config
+{
 class Configuration;
 } /* namespace config */
 

--- a/src/feed/FeedFactory.h
+++ b/src/feed/FeedFactory.h
@@ -21,10 +21,15 @@
 
 #pragma once
 
-#include <memory>
 #include <boost/optional.hpp>
+#include <memory>
+#include <string>
 
-#include "../config/Configuration.h"
+#include "../config/PropertyMap.h"
+
+namespace config {
+class Configuration;
+} /* namespace config */
 
 namespace data
 {

--- a/src/feed/GpsFeed.cpp
+++ b/src/feed/GpsFeed.cpp
@@ -24,13 +24,13 @@
 #include <stdexcept>
 #include <unordered_map>
 
-#include "../Logger.hpp"
 #include "../config/Configuration.h"
 #include "../data/GpsData.h"
-#include "../object/GpsPosition.h"
-#include "client/GpsdClient.h"
-
 #include "../Logger.hpp"
+#include "../object/GpsPosition.h"
+#include "client/Client.h"
+#include "client/ClientManager.h"
+#include "parser/GpsParser.h"
 
 #ifdef COMPONENT
 #undef COMPONENT
@@ -42,7 +42,7 @@ namespace feed
 parser::GpsParser GpsFeed::smParser;
 
 GpsFeed::GpsFeed(const std::string& crName, const config::KeyValueMap& crKvMap,
-                 std::shared_ptr<data::GpsData>& pData)
+                 std::shared_ptr<data::GpsData> pData)
     : Feed(crName, crKvMap, pData)
 {
     Logger::debug(crName, " constructed ", COMPONENT);

--- a/src/feed/GpsFeed.cpp
+++ b/src/feed/GpsFeed.cpp
@@ -44,14 +44,10 @@ parser::GpsParser GpsFeed::smParser;
 GpsFeed::GpsFeed(const std::string& crName, const config::KeyValueMap& crKvMap,
                  std::shared_ptr<data::GpsData> pData)
     : Feed(crName, crKvMap, pData)
-{
-    Logger::debug(crName, " constructed ", COMPONENT);
-}
+{}
 
 GpsFeed::~GpsFeed() noexcept
-{
-    Logger::debug(mName, " destructed ", COMPONENT);
-}
+{}
 
 void GpsFeed::registerToClient(client::ClientManager& rManager)
 {
@@ -62,7 +58,6 @@ void GpsFeed::registerToClient(client::ClientManager& rManager)
 
 void GpsFeed::process(const std::string& crResponse) noexcept
 {
-    Logger::debug(mName, " process called");
     object::GpsPosition pos(getPriority());
     if(smParser.unpack(crResponse, pos))
     {
@@ -78,7 +73,6 @@ void GpsFeed::process(const std::string& crResponse) noexcept
             Logger::info(COMPONENT " ", mName, ": ", e.what());
             auto client = std::shared_ptr<client::Client>(mSubsribedClient);
             client->stop();
-            Logger::debug("returned from gpsfeed stop call");
             return;
         }
     }

--- a/src/feed/GpsFeed.cpp
+++ b/src/feed/GpsFeed.cpp
@@ -71,7 +71,7 @@ void GpsFeed::process(const std::string& crResponse) noexcept
         catch(const std::runtime_error& e)
         {
             Logger::info(COMPONENT " ", mName, ": ", e.what());
-            auto client = std::shared_ptr<client::Client>(mSubsribedClient);
+            std::shared_ptr<client::Client> client(mSubsribedClient);
             client->stop();
             return;
         }

--- a/src/feed/GpsFeed.cpp
+++ b/src/feed/GpsFeed.cpp
@@ -53,7 +53,7 @@ GpsFeed::~GpsFeed() noexcept
     Logger::debug(mName, " destructed ", COMPONENT);
 }
 
-void GpsFeed::registerClient(client::ClientManager& rManager)
+void GpsFeed::registerToClient(client::ClientManager& rManager)
 {
     mSubsribedClient = rManager.subscribe(
         shared_from_this(), {mKvMap.find(KV_KEY_HOST)->second, mKvMap.find(KV_KEY_PORT)->second},
@@ -68,7 +68,7 @@ void GpsFeed::process(const std::string& crResponse) noexcept
     {
         try
         {
-            if(mpData->update(std::move(pos), mDataSlot))
+            if(mpData->update(std::move(pos)))
             {
                 throw std::runtime_error("received good position -> stop");
             }

--- a/src/feed/GpsFeed.cpp
+++ b/src/feed/GpsFeed.cpp
@@ -24,9 +24,9 @@
 #include <stdexcept>
 #include <unordered_map>
 
+#include "../Logger.hpp"
 #include "../config/Configuration.h"
 #include "../data/GpsData.h"
-#include "../Logger.hpp"
 #include "../object/GpsPosition.h"
 #include "client/Client.h"
 #include "client/ClientManager.h"

--- a/src/feed/GpsFeed.h
+++ b/src/feed/GpsFeed.h
@@ -24,12 +24,14 @@
 #include <memory>
 #include <string>
 
-#include "../config/PropertyMap.h"
 #include "../Defines.h"
+#include "../config/PropertyMap.h"
 #include "Feed.h"
 
-namespace feed {
-namespace parser {
+namespace feed
+{
+namespace parser
+{
 class GpsParser;
 } /* namespace parser */
 } /* namespace feed */

--- a/src/feed/GpsFeed.h
+++ b/src/feed/GpsFeed.h
@@ -66,7 +66,7 @@ public:
      */
     virtual ~GpsFeed() noexcept;
 
-    void registerClient(client::ClientManager& rManager) override;
+    void registerToClient(client::ClientManager& rManager) override;
 
     /**
      * @see Feed#process

--- a/src/feed/GpsFeed.h
+++ b/src/feed/GpsFeed.h
@@ -69,7 +69,7 @@ public:
      * @fn ~GpsFeed
      * @brief Destructor
      */
-    virtual ~GpsFeed() noexcept;
+    ~GpsFeed() noexcept;
 
     void registerToClient(client::ClientManager& rManager) override;
 

--- a/src/feed/GpsFeed.h
+++ b/src/feed/GpsFeed.h
@@ -21,15 +21,18 @@
 
 #pragma once
 
-#include <cstddef>
 #include <memory>
 #include <string>
 
-#include "../Defines.h"
 #include "../config/PropertyMap.h"
-#include "parser/GpsParser.h"
-
+#include "../Defines.h"
 #include "Feed.h"
+
+namespace feed {
+namespace parser {
+class GpsParser;
+} /* namespace parser */
+} /* namespace feed */
 
 namespace data
 {
@@ -58,7 +61,7 @@ public:
      * @throw std::logic_error from parent constructor
      */
     GpsFeed(const std::string& crName, const config::KeyValueMap& crKvMap,
-            std::shared_ptr<data::GpsData>& pData);
+            std::shared_ptr<data::GpsData> pData);
 
     /**
      * @fn ~GpsFeed

--- a/src/feed/GpsFeed.h
+++ b/src/feed/GpsFeed.h
@@ -52,7 +52,7 @@ namespace feed
 class GpsFeed : public Feed, public std::enable_shared_from_this<GpsFeed>
 {
 public:
-    NON_COPYABLE(GpsFeed)
+    NOT_COPYABLE(GpsFeed)
 
     /**
      * @fn GpsFeed

--- a/src/feed/SbsFeed.cpp
+++ b/src/feed/SbsFeed.cpp
@@ -41,7 +41,7 @@ SbsFeed::SbsFeed(const std::string& crName, const config::KeyValueMap& crKvMap,
 SbsFeed::~SbsFeed() noexcept
 {}
 
-void SbsFeed::registerClient(client::ClientManager& rManager)
+void SbsFeed::registerToClient(client::ClientManager& rManager)
 {
     mSubsribedClient = rManager.subscribe(
         shared_from_this(), {mKvMap.find(KV_KEY_HOST)->second, mKvMap.find(KV_KEY_PORT)->second},
@@ -53,7 +53,7 @@ void SbsFeed::process(const std::string& crResponse) noexcept
     object::Aircraft ac(getPriority());
     if(smParser.unpack(crResponse, ac))
     {
-        mpData->update(std::move(ac), mDataSlot);
+        mpData->update(std::move(ac));
     }
 }
 

--- a/src/feed/SbsFeed.cpp
+++ b/src/feed/SbsFeed.cpp
@@ -26,13 +26,16 @@
 #include "../config/Configuration.h"
 #include "../data/AircraftData.h"
 #include "../object/Aircraft.h"
+#include "client/Client.h"
+#include "client/ClientManager.h"
+#include "parser/SbsParser.h"
 
 namespace feed
 {
 parser::SbsParser SbsFeed::smParser;
 
 SbsFeed::SbsFeed(const std::string& crName, const config::KeyValueMap& crKvMap,
-                 std::shared_ptr<data::AircraftData>& pData, std::int32_t vMaxHeight)
+                 std::shared_ptr<data::AircraftData> pData, std::int32_t vMaxHeight)
     : Feed(crName, crKvMap, pData)
 {
     smParser.setMaxHeight(vMaxHeight);

--- a/src/feed/SbsFeed.h
+++ b/src/feed/SbsFeed.h
@@ -72,7 +72,7 @@ public:
      * @fn ~SbsFeed
      * @brief Destructor
      */
-    virtual ~SbsFeed() noexcept;
+    ~SbsFeed() noexcept;
 
     void registerToClient(client::ClientManager& rManager) override;
 

--- a/src/feed/SbsFeed.h
+++ b/src/feed/SbsFeed.h
@@ -69,7 +69,7 @@ public:
      */
     virtual ~SbsFeed() noexcept;
 
-    void registerClient(client::ClientManager& rManager) override;
+    void registerToClient(client::ClientManager& rManager) override;
 
     /**
      * @see Feed#process

--- a/src/feed/SbsFeed.h
+++ b/src/feed/SbsFeed.h
@@ -25,12 +25,14 @@
 #include <memory>
 #include <string>
 
-#include "../config/PropertyMap.h"
 #include "../Defines.h"
+#include "../config/PropertyMap.h"
 #include "Feed.h"
 
-namespace feed {
-namespace parser {
+namespace feed
+{
+namespace parser
+{
 class SbsParser;
 } /* namespace parser */
 } /* namespace feed */

--- a/src/feed/SbsFeed.h
+++ b/src/feed/SbsFeed.h
@@ -54,7 +54,7 @@ namespace feed
 class SbsFeed : public Feed, public std::enable_shared_from_this<SbsFeed>
 {
 public:
-    NON_COPYABLE(SbsFeed)
+    NOT_COPYABLE(SbsFeed)
 
     /**
      * @fn SbsFeed

--- a/src/feed/SbsFeed.h
+++ b/src/feed/SbsFeed.h
@@ -21,16 +21,19 @@
 
 #pragma once
 
-#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <string>
 
-#include "../Defines.h"
 #include "../config/PropertyMap.h"
-#include "parser/SbsParser.h"
-
+#include "../Defines.h"
 #include "Feed.h"
+
+namespace feed {
+namespace parser {
+class SbsParser;
+} /* namespace parser */
+} /* namespace feed */
 
 /// @namespace data
 namespace data
@@ -61,7 +64,7 @@ public:
      * @throw std::logic_error from parent constructor
      */
     SbsFeed(const std::string& crName, const config::KeyValueMap& crKvMap,
-            std::shared_ptr<data::AircraftData>& pData, std::int32_t vMaxHeight);
+            std::shared_ptr<data::AircraftData> pData, std::int32_t vMaxHeight);
 
     /**
      * @fn ~SbsFeed

--- a/src/feed/WindFeed.cpp
+++ b/src/feed/WindFeed.cpp
@@ -34,13 +34,12 @@ parser::WindParser WindFeed::smParser;
 WindFeed::WindFeed(const std::string& crName, const config::KeyValueMap& crKvMap,
                    std::shared_ptr<data::WindData>& pData)
     : Feed(crName, crKvMap, pData)
-
 {}
 
 WindFeed::~WindFeed() noexcept
 {}
 
-void WindFeed::registerClient(client::ClientManager& rManager)
+void WindFeed::registerToClient(client::ClientManager& rManager)
 {
     mSubsribedClient = rManager.subscribe(
         shared_from_this(), {mKvMap.find(KV_KEY_HOST)->second, mKvMap.find(KV_KEY_PORT)->second},
@@ -52,7 +51,7 @@ void WindFeed::process(const std::string& crResponse) noexcept
     object::Wind wind(getPriority());
     if(smParser.unpack(crResponse, wind))
     {
-        mpData->update(std::move(wind), mDataSlot);
+        mpData->update(std::move(wind));
     }
 }
 

--- a/src/feed/WindFeed.cpp
+++ b/src/feed/WindFeed.cpp
@@ -24,15 +24,18 @@
 #include <unordered_map>
 
 #include "../config/Configuration.h"
-#include "../data/WindData.h"
 #include "../object/Wind.h"
+#include "client/Client.h"
+#include "client/ClientManager.h"
+#include "parser/WindParser.h"
+#include "../data/WindData.h"
 
 namespace feed
 {
 parser::WindParser WindFeed::smParser;
 
 WindFeed::WindFeed(const std::string& crName, const config::KeyValueMap& crKvMap,
-                   std::shared_ptr<data::WindData>& pData)
+                   std::shared_ptr<data::WindData> pData)
     : Feed(crName, crKvMap, pData)
 {}
 

--- a/src/feed/WindFeed.cpp
+++ b/src/feed/WindFeed.cpp
@@ -24,11 +24,11 @@
 #include <unordered_map>
 
 #include "../config/Configuration.h"
+#include "../data/WindData.h"
 #include "../object/Wind.h"
 #include "client/Client.h"
 #include "client/ClientManager.h"
 #include "parser/WindParser.h"
-#include "../data/WindData.h"
 
 namespace feed
 {

--- a/src/feed/WindFeed.h
+++ b/src/feed/WindFeed.h
@@ -71,7 +71,7 @@ public:
      * @fn ~WindFeed
      * @brief Destructor
      */
-    virtual ~WindFeed() noexcept;
+    ~WindFeed() noexcept;
 
     void registerToClient(client::ClientManager& rManager) override;
 

--- a/src/feed/WindFeed.h
+++ b/src/feed/WindFeed.h
@@ -53,7 +53,7 @@ namespace feed
 class WindFeed : public Feed, public std::enable_shared_from_this<WindFeed>
 {
 public:
-    NON_COPYABLE(WindFeed)
+    NOT_COPYABLE(WindFeed)
 
     /**
      * @fn WindFeed

--- a/src/feed/WindFeed.h
+++ b/src/feed/WindFeed.h
@@ -21,15 +21,18 @@
 
 #pragma once
 
-#include <cstddef>
 #include <memory>
 #include <string>
 
-#include "../Defines.h"
 #include "../config/PropertyMap.h"
-#include "parser/WindParser.h"
-
+#include "../Defines.h"
 #include "Feed.h"
+
+namespace feed {
+namespace parser {
+class WindParser;
+} /* namespace parser */
+} /* namespace feed */
 
 /// @namespace data
 namespace data
@@ -60,7 +63,7 @@ public:
      * @throw std::logic_error from parent constructor
      */
     WindFeed(const std::string& crName, const config::KeyValueMap& crKvMap,
-             std::shared_ptr<data::WindData>& pData);
+             std::shared_ptr<data::WindData> pData);
 
     /**
      * @fn ~WindFeed

--- a/src/feed/WindFeed.h
+++ b/src/feed/WindFeed.h
@@ -68,7 +68,7 @@ public:
      */
     virtual ~WindFeed() noexcept;
 
-    void registerClient(client::ClientManager& rManager) override;
+    void registerToClient(client::ClientManager& rManager) override;
 
     /**
      * @see Feed#process

--- a/src/feed/WindFeed.h
+++ b/src/feed/WindFeed.h
@@ -24,12 +24,14 @@
 #include <memory>
 #include <string>
 
-#include "../config/PropertyMap.h"
 #include "../Defines.h"
+#include "../config/PropertyMap.h"
 #include "Feed.h"
 
-namespace feed {
-namespace parser {
+namespace feed
+{
+namespace parser
+{
 class WindParser;
 } /* namespace parser */
 } /* namespace feed */

--- a/src/feed/client/AprscClient.h
+++ b/src/feed/client/AprscClient.h
@@ -44,7 +44,7 @@ namespace client
 class AprscClient : public Client
 {
 public:
-    NON_COPYABLE(AprscClient)
+    NOT_COPYABLE(AprscClient)
 
     /**
      * @fn AprscClient

--- a/src/feed/client/AprscClient.h
+++ b/src/feed/client/AprscClient.h
@@ -60,7 +60,7 @@ public:
      * @fn ~AprscClient
      * @brief Destructor
      */
-    virtual ~AprscClient() noexcept;
+    ~AprscClient() noexcept;
 
     bool equals(const Client& crOther) const override;
 

--- a/src/feed/client/Client.cpp
+++ b/src/feed/client/Client.cpp
@@ -125,9 +125,9 @@ void Client::handleTimedConnect(const boost::system::error_code& crError) noexce
     }
     else
     {
-        Logger::error(mComponent, " cancel connect: ", crError.message());
         if(crError != boost::asio::error::operation_aborted)
         {
+            Logger::error(mComponent, " cancel connect: ", crError.message());
             boost::lock_guard<boost::mutex> lock(mMutex);
             stop();
         }

--- a/src/feed/client/Client.h
+++ b/src/feed/client/Client.h
@@ -21,16 +21,15 @@
 
 #pragma once
 
+#include <boost/asio.hpp>
+#include <boost/system/error_code.hpp>
+#include <boost/thread/mutex.hpp>
 #include <cstddef>
 #include <memory>
 #include <string>
 #include <vector>
-#include <boost/asio.hpp>
-#include <boost/system/error_code.hpp>
-#include <boost/thread/mutex.hpp>
 
 #include "../../Defines.h"
-#include "../../Parameters.h"
 
 /// @namespace feed
 namespace feed

--- a/src/feed/client/Client.h
+++ b/src/feed/client/Client.h
@@ -160,6 +160,8 @@ protected:
                                boost::asio::ip::tcp::resolver::iterator vResolverIt) noexcept
         = 0;
 
+    void closeSocket();
+
     /// @var mIoService
     /// Internal IO-service
     boost::asio::io_service mIoService;

--- a/src/feed/client/Client.h
+++ b/src/feed/client/Client.h
@@ -66,7 +66,7 @@ struct Endpoint
 class Client
 {
 public:
-    NON_COPYABLE(Client)
+    NOT_COPYABLE(Client)
 
     /**
      * @fn ~Client

--- a/src/feed/client/Client.h
+++ b/src/feed/client/Client.h
@@ -21,13 +21,13 @@
 
 #pragma once
 
-#include <boost/asio.hpp>
-#include <boost/system/error_code.hpp>
-#include <boost/thread/mutex.hpp>
 #include <cstddef>
 #include <memory>
 #include <string>
 #include <vector>
+#include <boost/asio.hpp>
+#include <boost/system/error_code.hpp>
+#include <boost/thread/mutex.hpp>
 
 #include "../../Defines.h"
 

--- a/src/feed/client/ClientManager.cpp
+++ b/src/feed/client/ClientManager.cpp
@@ -21,11 +21,11 @@
 
 #include "ClientManager.h"
 
+#include <stdexcept>
 #include <boost/asio.hpp>
 #include <boost/system/error_code.hpp>
 #include <boost/thread.hpp>
 #include <boost/thread/lock_guard.hpp>
-#include <stdexcept>
 
 #include "../../Logger.hpp"
 #include "../AprscFeed.h"

--- a/src/feed/client/ClientManager.cpp
+++ b/src/feed/client/ClientManager.cpp
@@ -22,7 +22,6 @@
 #include "ClientManager.h"
 
 #include <stdexcept>
-#include <boost/system/error_code.hpp>
 #include <boost/thread/lock_guard.hpp>
 
 #include "../AprscFeed.h"
@@ -76,9 +75,8 @@ std::weak_ptr<Client> ClientManager::subscribe(std::shared_ptr<Feed> rpFeed,
     return std::weak_ptr<Client>(*it);
 }
 
-void ClientManager::run(boost::asio::signal_set& rSigset)
+void ClientManager::run()
 {
-    rSigset.async_wait([this](const boost::system::error_code&, int) { stop(); });
     for(auto& it : mClients)
     {
         mThdGroup.create_thread([&]() {
@@ -91,10 +89,12 @@ void ClientManager::run(boost::asio::signal_set& rSigset)
 
 void ClientManager::stop()
 {
-    boost::lock_guard<boost::mutex> lock(mMutex);
-    for(const auto& it : mClients)
     {
-        it->lockAndStop();
+        boost::lock_guard<boost::mutex> lock(mMutex);
+        for(const auto& it : mClients)
+        {
+            it->lockAndStop();
+        }
     }
     mThdGroup.join_all();
 }

--- a/src/feed/client/ClientManager.cpp
+++ b/src/feed/client/ClientManager.cpp
@@ -27,7 +27,6 @@
 #include <boost/thread.hpp>
 #include <boost/thread/lock_guard.hpp>
 
-#include "../../Logger.hpp"
 #include "../AprscFeed.h"
 #include "../Feed.h"
 #include "AprscClient.h"
@@ -75,7 +74,6 @@ std::weak_ptr<Client> ClientManager::subscribe(std::shared_ptr<Feed> rpFeed,
             it = mClients.insert(std::make_shared<SensorClient>(crEndpoint)).first;
             break;
     }
-    Logger::debug("CM subscribed from ", rpFeed->getName(), " to ", (*it)->hash());
     (*it)->subscribe(rpFeed);
     return std::weak_ptr<Client>(*it);
 }
@@ -85,11 +83,8 @@ void ClientManager::run(boost::thread_group& rThdGroup, boost::asio::signal_set&
     rSigset.async_wait([this](const boost::system::error_code&, int) { stop(); });
     for(const auto& it : mClients)
     {
-        Logger::debug("CM create thread for ", it->hash());
         rThdGroup.create_thread([&]() {
-            Logger::debug("CM run client ", it->hash());
             it->run();
-            Logger::debug("CM returned from client run call -> erase");
             boost::lock_guard<boost::mutex> lock(mMutex);
             mClients.erase(it);
         });

--- a/src/feed/client/ClientManager.cpp
+++ b/src/feed/client/ClientManager.cpp
@@ -19,19 +19,21 @@
  }
  */
 
+#include "ClientManager.h"
+
 #include <boost/asio.hpp>
+#include <boost/system/error_code.hpp>
 #include <boost/thread.hpp>
 #include <boost/thread/lock_guard.hpp>
+#include <stdexcept>
 
+#include "../../Logger.hpp"
 #include "../AprscFeed.h"
 #include "../Feed.h"
 #include "AprscClient.h"
-#include "ClientManager.h"
 #include "GpsdClient.h"
 #include "SbsClient.h"
 #include "SensorClient.h"
-
-#include "../../Logger.hpp"
 
 namespace feed
 {

--- a/src/feed/client/ClientManager.h
+++ b/src/feed/client/ClientManager.h
@@ -21,12 +21,12 @@
 
 #pragma once
 
-#include <boost/asio.hpp>
-#include <boost/thread/mutex.hpp>
 #include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <unordered_set>
+#include <boost/asio.hpp>
+#include <boost/thread/mutex.hpp>
 
 #include "../../Defines.h"
 #include "Client.h"

--- a/src/feed/client/ClientManager.h
+++ b/src/feed/client/ClientManager.h
@@ -25,7 +25,6 @@
 #include <cstdint>
 #include <memory>
 #include <unordered_set>
-#include <boost/asio.hpp>
 #include <boost/thread.hpp>
 #include <boost/thread/mutex.hpp>
 
@@ -72,7 +71,7 @@ public:
     std::weak_ptr<Client> subscribe(std::shared_ptr<Feed> rpFeed, const Endpoint& crEndpoint,
                                     Protocol vProtocol);
 
-    void run(boost::asio::signal_set& rSigset);
+    void run();
 
     void stop();
 

--- a/src/feed/client/ClientManager.h
+++ b/src/feed/client/ClientManager.h
@@ -26,15 +26,11 @@
 #include <memory>
 #include <unordered_set>
 #include <boost/asio.hpp>
+#include <boost/thread.hpp>
 #include <boost/thread/mutex.hpp>
 
 #include "../../Defines.h"
 #include "Client.h"
-
-namespace boost
-{
-class thread_group;
-}  // namespace boost
 
 namespace feed
 {
@@ -76,12 +72,14 @@ public:
     std::weak_ptr<Client> subscribe(std::shared_ptr<Feed> rpFeed, const Endpoint& crEndpoint,
                                     Protocol vProtocol);
 
-    void run(boost::thread_group& rThdGroup, boost::asio::signal_set& rSigset);
+    void run(boost::asio::signal_set& rSigset);
 
     void stop();
 
 private:
     ClientSet mClients;
+
+    boost::thread_group mThdGroup;
 
     boost::mutex mMutex;
 };

--- a/src/feed/client/ClientManager.h
+++ b/src/feed/client/ClientManager.h
@@ -21,10 +21,12 @@
 
 #pragma once
 
-#include <iterator>
+#include <boost/asio.hpp>
+#include <boost/thread/mutex.hpp>
+#include <cstddef>
+#include <cstdint>
 #include <memory>
 #include <unordered_set>
-#include <boost/thread/mutex.hpp>
 
 #include "../../Defines.h"
 #include "Client.h"

--- a/src/feed/client/ClientManager.h
+++ b/src/feed/client/ClientManager.h
@@ -28,7 +28,6 @@
 #include <boost/thread.hpp>
 #include <boost/thread/mutex.hpp>
 
-#include "../../Defines.h"
 #include "Client.h"
 
 namespace feed
@@ -66,7 +65,9 @@ public:
         SENSOR
     };
 
-    DEFAULT_CTOR_DTOR(ClientManager)
+    ClientManager();
+
+    ~ClientManager() noexcept;
 
     std::weak_ptr<Client> subscribe(std::shared_ptr<Feed> rpFeed, const Endpoint& crEndpoint,
                                     Protocol vProtocol);

--- a/src/feed/client/GpsdClient.cpp
+++ b/src/feed/client/GpsdClient.cpp
@@ -21,6 +21,7 @@
 
 #include "GpsdClient.h"
 
+#include <string>
 #include <boost/bind.hpp>
 #include <boost/thread/lock_guard.hpp>
 

--- a/src/feed/client/GpsdClient.cpp
+++ b/src/feed/client/GpsdClient.cpp
@@ -37,20 +37,14 @@ namespace feed
 namespace client
 {
 GpsdClient::GpsdClient(const Endpoint& crEndpoint) : Client(crEndpoint, COMPONENT)
-{
-    Logger::debug(COMPONENT " constructed");
-}
+{}
 
 GpsdClient::~GpsdClient() noexcept
-{
-    Logger::debug(COMPONENT " destructed");
-}
+{}
 
 void GpsdClient::connect()
 {
-    Logger::debug(COMPONENT " connect called");
     mRunning = true;
-    Logger::debug(COMPONENT " is running");
     boost::asio::ip::tcp::resolver::query query(
         mEndpoint.host, mEndpoint.port, boost::asio::ip::tcp::resolver::query::canonical_name);
     mResolver.async_resolve(query, boost::bind(&GpsdClient::handleResolve, this,
@@ -73,10 +67,7 @@ void GpsdClient::handleResolve(const boost::system::error_code& crError,
     {
         Logger::error(COMPONENT " resolve host: ", crError.message());
         boost::lock_guard<boost::mutex> lock(mMutex);
-        if(mSocket.is_open())
-        {
-            mSocket.close();
-        }
+        closeSocket();
         timedConnect();
     }
 }
@@ -97,20 +88,15 @@ void GpsdClient::handleConnect(const boost::system::error_code& crError,
     {
         Logger::error(COMPONENT " connect: ", crError.message());
         boost::lock_guard<boost::mutex> lock(mMutex);
-        if(mSocket.is_open())
-        {
-            mSocket.close();
-        }
+        closeSocket();
         timedConnect();
     }
 }
 
 void GpsdClient::stop()
 {
-    Logger::debug(COMPONENT " stop called");
     if(mRunning && mSocket.is_open())
     {
-        Logger::debug(COMPONENT " is running");
         boost::asio::async_write(mSocket, boost::asio::buffer("?WATCH={\"enable\":false}\r\n"),
                                  [this](const boost::system::error_code& crError, std::size_t) {
                                      if(!crError)

--- a/src/feed/client/GpsdClient.h
+++ b/src/feed/client/GpsdClient.h
@@ -58,7 +58,7 @@ public:
      * @fn ~GpsdClient
      * @brief Destructor
      */
-    virtual ~GpsdClient() noexcept;
+    ~GpsdClient() noexcept;
 
 private:
     /**

--- a/src/feed/client/GpsdClient.h
+++ b/src/feed/client/GpsdClient.h
@@ -22,7 +22,6 @@
 #pragma once
 
 #include <cstddef>
-#include <string>
 #include <boost/asio.hpp>
 #include <boost/system/error_code.hpp>
 

--- a/src/feed/client/GpsdClient.h
+++ b/src/feed/client/GpsdClient.h
@@ -43,7 +43,7 @@ namespace client
 class GpsdClient : public Client
 {
 public:
-    NON_COPYABLE(GpsdClient)
+    NOT_COPYABLE(GpsdClient)
 
     /**
      * @fn GpsdClient

--- a/src/feed/client/SbsClient.cpp
+++ b/src/feed/client/SbsClient.cpp
@@ -22,6 +22,7 @@
 #include "SbsClient.h"
 
 #include <boost/bind.hpp>
+#include <string>
 #include <boost/thread/lock_guard.hpp>
 
 #include "../../Logger.hpp"

--- a/src/feed/client/SbsClient.cpp
+++ b/src/feed/client/SbsClient.cpp
@@ -67,10 +67,7 @@ void SbsClient::handleResolve(const boost::system::error_code& crError,
     {
         Logger::error(COMPONENT " resolve host: ", crError.message());
         boost::lock_guard<boost::mutex> lock(mMutex);
-        if(mSocket.is_open())
-        {
-            mSocket.close();
-        }
+        closeSocket();
         timedConnect();
     }
 }
@@ -89,10 +86,7 @@ void SbsClient::handleConnect(const boost::system::error_code& crError,
     {
         Logger::error(COMPONENT " connect: ", crError.message());
         boost::lock_guard<boost::mutex> lock(mMutex);
-        if(mSocket.is_open())
-        {
-            mSocket.close();
-        }
+        closeSocket();
         timedConnect();
     }
 }

--- a/src/feed/client/SbsClient.cpp
+++ b/src/feed/client/SbsClient.cpp
@@ -21,8 +21,8 @@
 
 #include "SbsClient.h"
 
-#include <boost/bind.hpp>
 #include <string>
+#include <boost/bind.hpp>
 #include <boost/thread/lock_guard.hpp>
 
 #include "../../Logger.hpp"

--- a/src/feed/client/SbsClient.h
+++ b/src/feed/client/SbsClient.h
@@ -56,7 +56,7 @@ public:
      * @fn ~SbsClient
      * @brief Destructor
      */
-    virtual ~SbsClient() noexcept;
+    ~SbsClient() noexcept;
 
 private:
     /**

--- a/src/feed/client/SbsClient.h
+++ b/src/feed/client/SbsClient.h
@@ -41,7 +41,7 @@ namespace client
 class SbsClient : public Client
 {
 public:
-    NON_COPYABLE(SbsClient)
+    NOT_COPYABLE(SbsClient)
 
     /**
      * @fn SbsClient

--- a/src/feed/client/SbsClient.h
+++ b/src/feed/client/SbsClient.h
@@ -21,7 +21,6 @@
 
 #pragma once
 
-#include <string>
 #include <boost/asio.hpp>
 #include <boost/system/error_code.hpp>
 

--- a/src/feed/client/SensorClient.cpp
+++ b/src/feed/client/SensorClient.cpp
@@ -105,10 +105,7 @@ void SensorClient::handleResolve(const boost::system::error_code& crError,
     {
         Logger::error(COMPONENT " resolve host: ", crError.message());
         boost::lock_guard<boost::mutex> lock(mMutex);
-        if(mSocket.is_open())
-        {
-            mSocket.close();
-        }
+        closeSocket();
         timedConnect();
     }
 }
@@ -127,10 +124,7 @@ void SensorClient::handleConnect(const boost::system::error_code& crError,
     {
         Logger::error(COMPONENT " connect: ", crError.message());
         boost::lock_guard<boost::mutex> lock(mMutex);
-        if(mSocket.is_open())
-        {
-            mSocket.close();
-        }
+        closeSocket();
         timedConnect();
     }
 }

--- a/src/feed/client/SensorClient.cpp
+++ b/src/feed/client/SensorClient.cpp
@@ -21,6 +21,7 @@
 
 #include "SensorClient.h"
 
+#include <string>
 #include <boost/bind.hpp>
 #include <boost/date_time.hpp>
 #include <boost/operators.hpp>

--- a/src/feed/client/SensorClient.h
+++ b/src/feed/client/SensorClient.h
@@ -21,13 +21,10 @@
 
 #pragma once
 
-#include <string>
 #include <boost/asio.hpp>
 #include <boost/system/error_code.hpp>
 
 #include "../../Defines.h"
-#include "../../Parameters.h"
-
 #include "Client.h"
 
 #ifdef WINDCLIENT_RECEIVE_TIMEOUT
@@ -39,7 +36,7 @@
 /// @namespace feed
 namespace feed
 {
-class Feed;
+
 /// @namespace client
 namespace client
 {

--- a/src/feed/client/SensorClient.h
+++ b/src/feed/client/SensorClient.h
@@ -62,7 +62,7 @@ public:
      * @fn ~SensorClient
      * @brief Destructor
      */
-    virtual ~SensorClient() noexcept;
+    ~SensorClient() noexcept;
 
 private:
     /**

--- a/src/feed/client/SensorClient.h
+++ b/src/feed/client/SensorClient.h
@@ -47,7 +47,7 @@ namespace client
 class SensorClient : public Client
 {
 public:
-    NON_COPYABLE(SensorClient)
+    NOT_COPYABLE(SensorClient)
 
     /**
      * @fn SensorClient

--- a/src/feed/client/SensorClient.h
+++ b/src/feed/client/SensorClient.h
@@ -36,7 +36,6 @@
 /// @namespace feed
 namespace feed
 {
-
 /// @namespace client
 namespace client
 {

--- a/src/feed/parser/AprsParser.cpp
+++ b/src/feed/parser/AprsParser.cpp
@@ -26,6 +26,7 @@
 
 #include "../../Math.hpp"
 #include "../../object/GpsPosition.h"
+#include "../../object/TimeStamp.h"
 
 /// @def RE_APRS_TIME
 /// APRS regex match group of time

--- a/src/feed/parser/AprsParser.h
+++ b/src/feed/parser/AprsParser.h
@@ -44,7 +44,9 @@ namespace parser
 class AprsParser : public Parser<object::Aircraft>
 {
 public:
-    DEFAULT_CTOR_DTOR(AprsParser)
+    AprsParser();
+
+    ~AprsParser() noexcept;
 
     /**
      * @fn unpack

--- a/src/feed/parser/AtmosphereParser.h
+++ b/src/feed/parser/AtmosphereParser.h
@@ -23,7 +23,6 @@
 
 #include <string>
 
-#include "../../Defines.h"
 #include "../../object/Atmosphere.h"
 #include "Parser.hpp"
 
@@ -41,7 +40,9 @@ namespace parser
 class AtmosphereParser : public Parser<object::Atmosphere>
 {
 public:
-    DEFAULT_CTOR_DTOR(AtmosphereParser)
+    AtmosphereParser();
+
+    ~AtmosphereParser() noexcept;
 
     /**
      * @fn unpack

--- a/src/feed/parser/AtmosphereParser.h
+++ b/src/feed/parser/AtmosphereParser.h
@@ -25,7 +25,6 @@
 
 #include "../../Defines.h"
 #include "../../object/Atmosphere.h"
-
 #include "Parser.hpp"
 
 /// @namespace feed

--- a/src/feed/parser/GpsParser.cpp
+++ b/src/feed/parser/GpsParser.cpp
@@ -24,6 +24,7 @@
 #include <stdexcept>
 
 #include "../../Math.hpp"
+#include "../../object/TimeStamp.h"
 
 /// @def RE_GGA_TIME
 /// GGA regex match capture group of time

--- a/src/feed/parser/GpsParser.h
+++ b/src/feed/parser/GpsParser.h
@@ -51,7 +51,7 @@ public:
      * @fn ~GpsParser
      * @brief Destructor
      */
-    virtual ~GpsParser() noexcept;
+    ~GpsParser() noexcept;
 
     /**
      * @fn unpack

--- a/src/feed/parser/Parser.hpp
+++ b/src/feed/parser/Parser.hpp
@@ -23,8 +23,6 @@
 
 #include <string>
 
-#include "../../Defines.h"
-
 /// @namespace feed
 namespace feed
 {
@@ -40,7 +38,11 @@ template<typename T>
 class Parser
 {
 public:
-    DEFAULT_CTOR_DTOR_INLINE(Parser)
+    Parser()
+    {}
+
+    virtual ~Parser() noexcept
+    {}
 
     /**
      * @fn unpack

--- a/src/feed/parser/SbsParser.cpp
+++ b/src/feed/parser/SbsParser.cpp
@@ -21,8 +21,8 @@
 
 #include "SbsParser.h"
 
-#include <limits>
 #include <cstddef>
+#include <limits>
 #include <stdexcept>
 
 #include "../../Math.hpp"

--- a/src/feed/parser/SbsParser.cpp
+++ b/src/feed/parser/SbsParser.cpp
@@ -22,6 +22,7 @@
 #include "SbsParser.h"
 
 #include <limits>
+#include <cstddef>
 #include <stdexcept>
 
 #include "../../Math.hpp"

--- a/src/feed/parser/SbsParser.h
+++ b/src/feed/parser/SbsParser.h
@@ -21,7 +21,6 @@
 
 #pragma once
 
-#include <cstddef>
 #include <cstdint>
 #include <string>
 

--- a/src/feed/parser/SbsParser.h
+++ b/src/feed/parser/SbsParser.h
@@ -43,7 +43,9 @@ namespace parser
 class SbsParser : public Parser<object::Aircraft>
 {
 public:
-    DEFAULT_CTOR_DTOR(SbsParser)
+    SbsParser();
+
+    ~SbsParser() noexcept;
 
     /**
      * @fn unpack

--- a/src/feed/parser/WindParser.h
+++ b/src/feed/parser/WindParser.h
@@ -23,7 +23,6 @@
 
 #include <string>
 
-#include "../../Defines.h"
 #include "../../object/Wind.h"
 
 #include "Parser.hpp"
@@ -35,7 +34,10 @@ namespace parser
 class WindParser : public Parser<object::Wind>
 {
 public:
-    DEFAULT_CTOR_DTOR(WindParser)
+    WindParser();
+
+    ~WindParser() noexcept;
+
     /**
      * @fn unpack
      * @brief Unpack into Climate.

--- a/src/object/Aircraft.cpp
+++ b/src/object/Aircraft.cpp
@@ -47,15 +47,15 @@ void Aircraft::assign(Object&& rvOther)
     this->mMovement     = rvUpdate.mMovement;
     this->mTimeStamp    = rvUpdate.mTimeStamp;
     this->mFullInfo     = rvUpdate.mFullInfo;
-    this->mUpdateAge    = 0;
 }
 
-bool Aircraft::canUpdate(const Object& crOther, std::uint32_t vAttempts) const
+bool Aircraft::canUpdate(const Object& crOther) const
 {
-    const Aircraft& crUpdate = static_cast<const Aircraft&>(crOther);
-    return (crUpdate.mTargetType == TargetType::TRANSPONDER
-            || this->mTargetType == TargetType::FLARM)
-           && (this->mLastPriority * vAttempts >= crUpdate.mLastPriority);
+    const Aircraft& crToUpdate = static_cast<const Aircraft&>(crOther);
+    return (this->mTimeStamp > crToUpdate.mTimeStamp)
+           && (crToUpdate.mTargetType == TargetType::TRANSPONDER
+               || this->mTargetType == TargetType::FLARM)
+           && Object::canUpdate(crOther);
 }
 
 void Aircraft::setAircraftType(Aircraft::AircraftType vType)

--- a/src/object/Aircraft.h
+++ b/src/object/Aircraft.h
@@ -111,7 +111,7 @@ public:
         OGN          = 3
     };
 
-    DEFAULT_CTOR_DTOR(Aircraft)
+    Aircraft();
 
     /**
      * @fn Aircraft
@@ -119,6 +119,8 @@ public:
      * @param vPriority The initial priority
      */
     explicit Aircraft(std::uint32_t vPriority);
+
+    ~Aircraft() noexcept;
 
     /**
      * Define and declare getters and setters.

--- a/src/object/Aircraft.h
+++ b/src/object/Aircraft.h
@@ -128,7 +128,6 @@ public:
     GETSET_V(TargetType, mTargetType, TargetType)
     GETTER_V(AircraftType, mAircraftType, AircraftType)
     GETSET_V(bool, mFullInfo, FullInfoAvailable)
-    GETTER_R(std::uint32_t, mUpdateAge, UpdateAge)
     GETSET_CR(Position, mPosition, Position)
     GETSET_CR(Movement, mMovement, Movement)
     GETSET_V(TimeStamp, mTimeStamp, TimeStamp)
@@ -169,7 +168,7 @@ private:
      * @param vAttempts The update attempt count
      * @return true if yes, else false
      */
-    bool canUpdate(const Object& crOther, std::uint32_t vAttempts) const override;
+    bool canUpdate(const Object& crOther) const override;
 
     /// @var mId
     /// Aircraft identifier
@@ -202,10 +201,6 @@ private:
     /// @var mFullInfo
     /// Is full set of information available?
     bool mFullInfo = false;
-
-    /// @var mUpdateAge
-    /// Times processed without update.
-    std::uint32_t mUpdateAge = 0;
 };
 
 }  // namespace object

--- a/src/object/Atmosphere.h
+++ b/src/object/Atmosphere.h
@@ -43,7 +43,7 @@ struct Climate;
 class Atmosphere : public Object
 {
 public:
-    DEFAULT_CTOR_DTOR(Atmosphere)
+    Atmosphere();
 
     /**
      * @fn Atmosphere
@@ -59,6 +59,8 @@ public:
      * @param vPriority The initial priority
      */
     Atmosphere(double vPressure, std::uint32_t vPriority);
+
+    ~Atmosphere() noexcept;
 
     /**
      * Define and declare getters and setters.

--- a/src/object/GpsPosition.cpp
+++ b/src/object/GpsPosition.cpp
@@ -43,4 +43,11 @@ void GpsPosition::assign(Object&& rvOther)
     this->mGeoid           = rvUpdate.mGeoid;
     this->mDilution        = rvUpdate.mDilution;
 }
+
+bool GpsPosition::canUpdate(const Object& crOther) const
+{
+    const GpsPosition& crToUpdate = static_cast<const GpsPosition&>(crOther);
+    return (this->mTimeStamp > crToUpdate.mTimeStamp) && Object::canUpdate(crOther);
+}
+
 }  // namespace object

--- a/src/object/GpsPosition.h
+++ b/src/object/GpsPosition.h
@@ -24,7 +24,6 @@
 #include <cstdint>
 
 #include "../Defines.h"
-
 #include "Object.h"
 #include "TimeStamp.h"
 

--- a/src/object/GpsPosition.h
+++ b/src/object/GpsPosition.h
@@ -90,7 +90,7 @@ private:
      */
     void assign(Object&& rvOther) override;
 
-        /**
+    /**
      * @fn canUpdate
      * @brief Check whether this Aircraft can update the other one.
      * @param crOther   The other Aircraft

--- a/src/object/GpsPosition.h
+++ b/src/object/GpsPosition.h
@@ -57,7 +57,7 @@ struct Position
 class GpsPosition : public Object
 {
 public:
-    DEFAULT_CTOR_DTOR(GpsPosition)
+    GpsPosition();
 
     /**
      * @fn GpsPosition
@@ -73,6 +73,8 @@ public:
      * @param vGeoid     The geoid
      */
     GpsPosition(const Position& crPosition, double vGeoid);
+
+    ~GpsPosition() noexcept;
 
     /**
      * Define and declare getters and setters.

--- a/src/object/GpsPosition.h
+++ b/src/object/GpsPosition.h
@@ -91,6 +91,15 @@ private:
      */
     void assign(Object&& rvOther) override;
 
+        /**
+     * @fn canUpdate
+     * @brief Check whether this Aircraft can update the other one.
+     * @param crOther   The other Aircraft
+     * @param vAttempts The update attempt count
+     * @return true if yes, else false
+     */
+    bool canUpdate(const Object& crOther) const override;
+
     /// @var mPosition
     /// The position
     Position mPosition{0.0, 0.0, 0};

--- a/src/object/Object.cpp
+++ b/src/object/Object.cpp
@@ -32,11 +32,12 @@ void Object::assign(Object&& crOther)
 {
     this->mSerialized   = std::move(crOther.mSerialized);
     this->mLastPriority = crOther.mLastPriority;
+    this->mUpdateAge    = 0;
 }
 
-bool Object::tryUpdate(Object&& rvOther, std::uint32_t vAttempts)
+bool Object::tryUpdate(Object&& rvOther)
 {
-    if(rvOther.canUpdate(*this, vAttempts))
+    if(rvOther.canUpdate(*this))
     {
         this->assign(std::move(rvOther));
         return true;
@@ -44,9 +45,9 @@ bool Object::tryUpdate(Object&& rvOther, std::uint32_t vAttempts)
     return false;
 }
 
-bool Object::canUpdate(const Object& crOther, std::uint32_t vAttempts) const
+bool Object::canUpdate(const Object& crOther) const
 {
-    return this->mLastPriority * vAttempts >= crOther.mLastPriority;
+    return this->mLastPriority >= crOther.mLastPriority || crOther.mUpdateAge >= OBJ_OUTDATED;
 }
 
 void Object::setSerialized(std::string&& rvSerialized)
@@ -58,4 +59,11 @@ const std::string& Object::getSerialized() const
 {
     return mSerialized;
 }
+
+Object& Object::operator++()
+{
+    ++mUpdateAge;
+    return *this;
+}
+
 }  // namespace object

--- a/src/object/Object.h
+++ b/src/object/Object.h
@@ -38,7 +38,7 @@ namespace object
 class Object
 {
 public:
-    DEFAULT_CTOR_DTOR(Object)
+    Object();
 
     /**
      * @fn Object
@@ -46,6 +46,8 @@ public:
      * @param vPriority The initial priority
      */
     explicit Object(std::uint32_t vPriority);
+
+    virtual ~Object() noexcept;
 
     /**
      * @fn tryUpdate

--- a/src/object/Object.h
+++ b/src/object/Object.h
@@ -22,6 +22,10 @@
 
 #include "../Defines.h"
 
+/// @def AC_OUTDATED
+/// Times until aircraft is outdated
+#define OBJ_OUTDATED 4
+
 /// @namespace object
 namespace object
 {
@@ -52,7 +56,7 @@ public:
      * @param vAttempts The update attempt count
      * @return true on success, else false
      */
-    virtual bool tryUpdate(Object&& rvOther, std::uint32_t vAttempts);
+    virtual bool tryUpdate(Object&& rvOther);
 
     /**
      * @fn setSerialized
@@ -67,6 +71,10 @@ public:
      * @return mSerialized
      */
     virtual const std::string& getSerialized() const;
+
+    Object& operator++();
+
+    GETTER_V(std::uint32_t, mUpdateAge, UpdateAge)
 
 protected:
     /**
@@ -83,7 +91,7 @@ protected:
      * @param vAttempts The update attempt count
      * @return true if yes, else false
      */
-    virtual bool canUpdate(const Object& crOther, std::uint32_t vAttempts) const;
+    virtual bool canUpdate(const Object& crOther) const;
 
     /// @var mLastPriority
     /// Got last update with this priority.
@@ -92,5 +100,9 @@ protected:
     /// @var mSerialized
     /// The string representation of this Objects data.
     std::string mSerialized;
+
+    /// @var mUpdateAge
+    /// Times processed without update.
+    std::uint32_t mUpdateAge = 0;
 };
 }  // namespace object

--- a/src/object/TimeStamp.cpp
+++ b/src/object/TimeStamp.cpp
@@ -20,18 +20,16 @@
  */
 
 #include "TimeStamp.h"
+#include <boost/date_time/posix_time/posix_time.hpp>
 
 namespace object
 {
-TimeStamp::TimeStamp() : mValue(0)
+TimeStamp::TimeStamp() : mValue(0), mYesterday(false)
 {}
 
 TimeStamp::TimeStamp(const std::string& crValue, Format vFormat)
 {
-    std::int32_t h = 99;
-    std::int32_t m = 99;
-    std::int32_t s = 99;
-    std::int32_t f = 9999;
+    std::int32_t h = 99, m = 99, s = 99, f = 9999;
     try
     {
         switch(vFormat)
@@ -62,7 +60,8 @@ TimeStamp::TimeStamp(const std::string& crValue, Format vFormat)
     {
         throw std::invalid_argument("");
     }
-    mValue = static_cast<std::uint32_t>(h * 3600000 + m * 60000 + s * 1000 + f);
+    mValue     = static_cast<std::uint64_t>(h * 3600000 + m * 60000 + s * 1000 + f);
+    mYesterday = mValue >= now();
 }
 
 TimeStamp::TimeStamp(const TimeStamp& crOther) : mValue(crOther.mValue)
@@ -77,18 +76,18 @@ TimeStamp& TimeStamp::operator=(const TimeStamp& crOther)
     return *this;
 }
 
-bool TimeStamp::operator<(const TimeStamp& crOther) const
+bool TimeStamp::operator>(const TimeStamp& crOther) const
 {
-    return this->mValue < crOther.mValue;
+    return (crOther.mYesterday && !this->mYesterday)
+           || ((!this->mYesterday || crOther.mYesterday) && this->mValue > crOther.mValue);
 }
 
-bool TimeStamp::operator<=(const TimeStamp& crOther) const
+std::uint64_t TimeStamp::now() const
 {
-    return this->mValue <= crOther.mValue;
+    return static_cast<std::uint64_t>(
+        boost::posix_time::time_duration(
+            boost::posix_time::microsec_clock::universal_time().time_of_day())
+            .total_milliseconds());
 }
 
-bool TimeStamp::operator==(const TimeStamp& crOther) const
-{
-    return this->mValue == crOther.mValue;
-}
-}
+}  // namespace object

--- a/src/object/TimeStamp.cpp
+++ b/src/object/TimeStamp.cpp
@@ -64,7 +64,8 @@ TimeStamp::TimeStamp(const std::string& crValue, Format vFormat)
     mYesterday = mValue >= now();
 }
 
-TimeStamp::TimeStamp(const TimeStamp& crOther) : mValue(crOther.mValue)
+TimeStamp::TimeStamp(const TimeStamp& crOther)
+    : mValue(crOther.mValue), mYesterday(crOther.mYesterday)
 {}
 
 TimeStamp::~TimeStamp() noexcept

--- a/src/object/TimeStamp.cpp
+++ b/src/object/TimeStamp.cpp
@@ -20,7 +20,9 @@
  */
 
 #include "TimeStamp.h"
+
 #include <boost/date_time/posix_time/posix_time.hpp>
+#include <stdexcept>
 
 namespace object
 {

--- a/src/object/TimeStamp.cpp
+++ b/src/object/TimeStamp.cpp
@@ -21,8 +21,8 @@
 
 #include "TimeStamp.h"
 
-#include <boost/date_time/posix_time/posix_time.hpp>
 #include <stdexcept>
+#include <boost/date_time/posix_time/posix_time.hpp>
 
 namespace object
 {

--- a/src/object/TimeStamp.h
+++ b/src/object/TimeStamp.h
@@ -22,7 +22,6 @@
 #pragma once
 
 #include <cstdint>
-#include <stdexcept>
 #include <string>
 
 #include "../Defines.h"

--- a/src/object/TimeStamp.h
+++ b/src/object/TimeStamp.h
@@ -80,32 +80,20 @@ public:
     TimeStamp& operator=(const TimeStamp& crOther);
 
     /**
-     * @fn operator <
-     * @brief Compare this value to be less than others.
-     * @param crOther The other TimeStamp
-     * @return true if less, else false
-     */
-    bool operator<(const TimeStamp& crOther) const;
-
-    /**
      * @fn operator <=
      * @brief Compare this value to be less than, or equals others.
      * @param crOther The other TimeStamp
      * @return true if less, or equals, else false
      */
-    bool operator<=(const TimeStamp& crOther) const;
-
-    /**
-     * @fn operator ==
-     * @brief Compare this value to be equals others.
-     * @param crOther The other TimeStamp
-     * @return true if equals, else false
-     */
-    bool operator==(const TimeStamp& crOther) const;
+    bool operator>(const TimeStamp& crOther) const;
 
 private:
+    std::uint64_t now() const;
+
     /// @var mValue
     /// The time in milliseconds
-    std::uint32_t mValue;
+    std::uint64_t mValue;
+
+    bool mYesterday;
 };
 }  // namespace object

--- a/src/object/TimeStamp.h
+++ b/src/object/TimeStamp.h
@@ -24,7 +24,6 @@
 #include <cstdint>
 #include <string>
 
-#include "../Defines.h"
 
 /// @namespace object
 namespace object
@@ -46,7 +45,7 @@ public:
         HH_MM_SS_FFF
     };
 
-    DEFAULT_CTOR_DTOR(TimeStamp)
+    TimeStamp();
 
     /**
      * @fn TimeStamp
@@ -69,6 +68,8 @@ public:
      * @param crOther The other TimeStamp
      */
     TimeStamp(const TimeStamp& crOther);
+
+    ~TimeStamp() noexcept;
 
     /**
      * @fn operator =

--- a/src/object/Wind.h
+++ b/src/object/Wind.h
@@ -24,7 +24,6 @@
 #include <cstdint>
 
 #include "../Defines.h"
-
 #include "Object.h"
 
 /// @namespace object

--- a/src/object/Wind.h
+++ b/src/object/Wind.h
@@ -23,7 +23,6 @@
 
 #include <cstdint>
 
-#include "../Defines.h"
 #include "Object.h"
 
 /// @namespace object
@@ -39,13 +38,15 @@ struct Climate;
 class Wind : public Object
 {
 public:
-    DEFAULT_CTOR_DTOR(Wind)
+    Wind();
 
     /**
      * @fn Wind
      * @brief Constructor
      */
     explicit Wind(std::uint32_t vPriority);
+
+    ~Wind() noexcept;
 };
 
 }  // namespace object

--- a/src/server/Connection.cpp
+++ b/src/server/Connection.cpp
@@ -21,7 +21,6 @@
 
 #include "Connection.h"
 
-#include <algorithm>
 #include <boost/move/move.hpp>
 #include <boost/system/error_code.hpp>
 

--- a/src/server/Connection.cpp
+++ b/src/server/Connection.cpp
@@ -44,10 +44,10 @@ Connection::~Connection() noexcept
 
 void Connection::stop()
 {
-    boost::system::error_code ignored_ec;
-    mSocket.shutdown(boost::asio::ip::tcp::socket::shutdown_both, ignored_ec);
     if(mSocket.is_open())
     {
+        boost::system::error_code ignored_ec;
+        mSocket.shutdown(boost::asio::ip::tcp::socket::shutdown_send, ignored_ec);
         mSocket.close();
     }
 }

--- a/src/server/Connection.cpp
+++ b/src/server/Connection.cpp
@@ -26,14 +26,16 @@
 
 namespace server
 {
-boost::shared_ptr<Connection> Connection::start(BOOST_RV_REF(boost::asio::ip::tcp::socket) rvSocket)
+std::unique_ptr<Connection> Connection::start(BOOST_RV_REF(boost::asio::ip::tcp::socket) rvSocket)
 {
-    return boost::shared_ptr<Connection>(new Connection(boost::move(rvSocket)));
+    return std::unique_ptr<Connection>(new Connection(boost::move(rvSocket)));
 }
 
 Connection::Connection(BOOST_RV_REF(boost::asio::ip::tcp::socket) rvSocket)
     : mSocket(boost::move(rvSocket)), mIpAddress(mSocket.remote_endpoint().address().to_string())
-{}
+{
+    mSocket.non_blocking(true);
+}
 
 Connection::~Connection() noexcept
 {

--- a/src/server/Connection.h
+++ b/src/server/Connection.h
@@ -21,11 +21,10 @@
 
 #pragma once
 
+#include <memory>
 #include <string>
 #include <boost/asio.hpp>
-#include <boost/enable_shared_from_this.hpp>
 #include <boost/move/move.hpp>
-#include <boost/shared_ptr.hpp>
 
 #include "../Defines.h"
 
@@ -37,7 +36,7 @@ namespace server
  * @brief TCP connection opened by the Server.
  * @see Server.h
  */
-class Connection : public boost::enable_shared_from_this<Connection>
+class Connection final
 {
 public:
     NON_COPYABLE(Connection)
@@ -54,7 +53,7 @@ public:
      * @param rvSocket The socket
      * @return a shared ptr to the Connection object
      */
-    static boost::shared_ptr<Connection> start(BOOST_RV_REF(boost::asio::ip::tcp::socket) rvSocket);
+    static std::unique_ptr<Connection> start(BOOST_RV_REF(boost::asio::ip::tcp::socket) rvSocket);
 
     /**
      * @fn stop

--- a/src/server/Connection.h
+++ b/src/server/Connection.h
@@ -45,7 +45,7 @@ public:
      * @fn ~Connection
      * @brief Destructor
      */
-    virtual ~Connection() noexcept;
+    ~Connection() noexcept;
 
     /**
      * @fn start

--- a/src/server/Connection.h
+++ b/src/server/Connection.h
@@ -39,7 +39,7 @@ namespace server
 class Connection final
 {
 public:
-    NON_COPYABLE(Connection)
+    NOT_COPYABLE(Connection)
 
     /**
      * @fn ~Connection

--- a/src/server/Server.cpp
+++ b/src/server/Server.cpp
@@ -127,9 +127,9 @@ void Server::handleAccept(const boost::system::error_code& crError) noexcept
             {
                 if(!it)
                 {
-                    it = Connection::start(boost::move(mSocket));
-                    Logger::info("(Server) connection from: ", it->getIpAddress());
                     success = true;
+                    it      = Connection::start(boost::move(mSocket));
+                    Logger::info("(Server) connection from: ", it->getIpAddress());
                     break;
                 }
             }

--- a/src/server/Server.cpp
+++ b/src/server/Server.cpp
@@ -82,7 +82,7 @@ void Server::accept()
 void Server::awaitStop(boost::asio::signal_set& rSigset)
 {
     rSigset.async_wait([this](const boost::system::error_code&, int) {
-    	boost::lock_guard<boost::mutex> lock(mMutex);
+        boost::lock_guard<boost::mutex> lock(mMutex);
         mAcceptor.close();
         stop();
     });

--- a/src/server/Server.cpp
+++ b/src/server/Server.cpp
@@ -49,6 +49,7 @@ void Server::run()
     mThread = boost::thread([this]() {
         accept();
         mIoService.run();
+        Logger::info("(Server) stopped");
     });
 }
 
@@ -85,22 +86,24 @@ void Server::accept()
 void Server::stop()
 {
     Logger::info("(Server) stopping all connections ...");
-    boost::lock_guard<boost::mutex> lock(mMutex);
-    if(mAcceptor.is_open())
     {
-        mAcceptor.close();
-    }
-    for(auto& it : mConnections)
-    {
-        if(it)
+        boost::lock_guard<boost::mutex> lock(mMutex);
+        if(mAcceptor.is_open())
         {
-            it.reset();
+            mAcceptor.close();
         }
-    }
-    mActiveConnections = 0;
-    if(!mIoService.stopped())
-    {
-        mIoService.stop();
+        for(auto& it : mConnections)
+        {
+            if(it)
+            {
+                it.reset();
+            }
+        }
+        mActiveConnections = 0;
+        if(!mIoService.stopped())
+        {
+            mIoService.stop();
+        }
     }
     if(mThread.joinable())
     {

--- a/src/server/Server.cpp
+++ b/src/server/Server.cpp
@@ -80,16 +80,14 @@ void Server::accept()
 
 void Server::awaitStop(boost::asio::signal_set& rSigset)
 {
-    rSigset.async_wait([this](const boost::system::error_code&, int) {
-        boost::lock_guard<boost::mutex> lock(mMutex);
-        mAcceptor.close();
-        stop();
-    });
+    rSigset.async_wait([this](const boost::system::error_code&, int) { stop(); });
 }
 
 void Server::stop()
 {
     Logger::info("(Server) stopping all connections...");
+    boost::lock_guard<boost::mutex> lock(mMutex);
+    mAcceptor.close();
     for(auto& it : mConnections)
     {
         if(it)

--- a/src/server/Server.h
+++ b/src/server/Server.h
@@ -22,13 +22,14 @@
 #pragma once
 
 #include <array>
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <string>
 #include <boost/asio.hpp>
 #include <boost/system/error_code.hpp>
-#include <boost/thread/mutex.hpp>
 #include <boost/thread.hpp>
+#include <boost/thread/mutex.hpp>
 
 #include "../Defines.h"
 #include "../Parameters.h"
@@ -110,6 +111,8 @@ private:
      */
     void handleAccept(const boost::system::error_code& crError) noexcept;
 
+    void attemptConnection() noexcept;
+
     boost::thread mThread;
 
     /// @var mMutex
@@ -131,6 +134,8 @@ private:
     /// @var mConnections
     /// Vector holding Connections
     std::array<std::unique_ptr<Connection>, S_MAX_CLIENTS> mConnections;
+
+    std::size_t mActiveConnections = 0;
 };
 
 }  // namespace server

--- a/src/server/Server.h
+++ b/src/server/Server.h
@@ -21,11 +21,11 @@
 
 #pragma once
 
+#include <array>
 #include <cstdint>
+#include <memory>
 #include <string>
-#include <vector>
 #include <boost/asio.hpp>
-#include <boost/shared_ptr.hpp>
 #include <boost/system/error_code.hpp>
 #include <boost/thread/mutex.hpp>
 
@@ -130,9 +130,9 @@ private:
     /// Socket
     boost::asio::ip::tcp::socket mSocket;
 
-    /// @var mClients
+    /// @var mConnections
     /// Vector holding Connections
-    std::vector<boost::shared_ptr<Connection>> mClients;
+    std::array<std::unique_ptr<Connection>, S_MAX_CLIENTS> mConnections;
 };
 
 }  // namespace server

--- a/src/server/Server.h
+++ b/src/server/Server.h
@@ -28,6 +28,7 @@
 #include <boost/asio.hpp>
 #include <boost/system/error_code.hpp>
 #include <boost/thread/mutex.hpp>
+#include <boost/thread.hpp>
 
 #include "../Defines.h"
 #include "../Parameters.h"
@@ -69,7 +70,14 @@ public:
      * @brief Run the Server.
      * @note Returns after all operations in the queue have returned.
      */
-    void run(boost::asio::signal_set& rSigset);
+    void run();
+
+    /**
+     * @fn stop
+     * @brief Stop all connections.
+     * @threadsafe
+     */
+    void stop();
 
     /**
      * @fn send
@@ -87,20 +95,6 @@ private:
     void accept();
 
     /**
-     * @fn awaitStop
-     * @brief Register stop-handler to signal set.
-     * @param rSigset The signal set
-     */
-    void awaitStop(boost::asio::signal_set& rSigset);
-
-    /**
-     * @fn stop
-     * @brief Stop all connections.
-     * @threadsafe
-     */
-    void stop();
-
-    /**
      * @fn isConnected
      * @brief Check whether an ip address already exists in the Connection container.
      * @param crIpAddress The ip address to check
@@ -115,6 +109,8 @@ private:
      * @threadsafe
      */
     void handleAccept(const boost::system::error_code& crError) noexcept;
+
+    boost::thread mThread;
 
     /// @var mMutex
     /// Mutex

--- a/src/server/Server.h
+++ b/src/server/Server.h
@@ -53,7 +53,7 @@ class Server
 public:
     NON_COPYABLE(Server)
 
-    DEFAULT_CTOR_DTOR(Server)
+    Server();
 
     /**
      * @fn Server
@@ -61,6 +61,8 @@ public:
      * @param vPort The port
      */
     explicit Server(std::uint16_t vPort);
+
+    ~Server() noexcept;
 
     /**
      * @fn run

--- a/src/server/Server.h
+++ b/src/server/Server.h
@@ -53,7 +53,7 @@ namespace server
 class Server
 {
 public:
-    NON_COPYABLE(Server)
+    NOT_COPYABLE(Server)
 
     Server();
 

--- a/test/Helper.hpp
+++ b/test/Helper.hpp
@@ -24,11 +24,14 @@
 #include <cstdint>
 #include <string>
 #include <boost/regex.hpp>
+#include <iostream>
 
 #include "../src/object/Aircraft.h"
 #include "framework/src/framework.h"
 
 #define TEST_FUNCTION(NAME) extern void NAME(TestSuitesRunner&);
+
+#define syso(M) std::cout << M << std::endl;
 
 namespace testsuite
 {
@@ -52,8 +55,7 @@ PROVIDE_COMPARATOR(std::string, EQUALS, equalsStr)
 PROVIDE_COMPARATOR(bool, EQUALS, equalsBool)
 PROVIDE_COMPARATOR(object::Aircraft::TargetType, EQUALS, equalsAtt)
 
-static boost::regex
-    pflauRe("\\$PFLAU,,,,1,0,([-]?\\d+?),0,(\\d+?),(\\d+?),(\\S{6})\\*(?:\\S{2})");
+static boost::regex pflauRe("\\$PFLAU,,,,1,0,([-]?\\d+?),0,(\\d+?),(\\d+?),(\\S{6})\\*(?:\\S{2})");
 static boost::regex pflaaRe(
     "\\$PFLAA,0,([-]?\\d+?),([-]?\\d+?),([-]?\\d+?),(\\d+?),(\\S{6}),(\\d{3})?,,(\\d+?)?,([-]?\\d+?\\.\\d+?)?,([0-9A-F])\\*(?:\\S{2})");
 static boost::regex gpsRe(

--- a/test/Helper.hpp
+++ b/test/Helper.hpp
@@ -22,23 +22,25 @@
 #pragma once
 
 #include <cstdint>
+#include <iostream>
 #include <string>
 #include <boost/regex.hpp>
-#include <iostream>
 
 #include "../src/object/Aircraft.h"
-#include "framework/src/framework.h"
+#include "framework/src/sctf.h"
 
-#define TEST_FUNCTION(NAME) extern void NAME(TestSuitesRunner&);
+#define TEST_FUNCTION(NAME) extern void NAME(test::TestSuitesRunner&);
 
 #define syso(M) std::cout << M << std::endl;
+
+#define assertEqStr(V, E) assertT(V, EQUALS, E, std::string)
 
 namespace sctf
 {
 namespace util
 {
 template<>
-inline std::string serialize(const object::Aircraft::TargetType& crTargetType)
+inline std::string serialize<object::Aircraft::TargetType>(const object::Aircraft::TargetType& crTargetType)
 {
     return std::to_string(static_cast<std::uint32_t>(crTargetType));
 }
@@ -47,7 +49,6 @@ inline std::string serialize(const object::Aircraft::TargetType& crTargetType)
 
 namespace helper
 {
-
 static boost::regex pflauRe("\\$PFLAU,,,,1,0,([-]?\\d+?),0,(\\d+?),(\\d+?),(\\S{6})\\*(?:\\S{2})");
 static boost::regex pflaaRe(
     "\\$PFLAA,0,([-]?\\d+?),([-]?\\d+?),([-]?\\d+?),(\\d+?),(\\S{6}),(\\d{3})?,,(\\d+?)?,([-]?\\d+?\\.\\d+?)?,([0-9A-F])\\*(?:\\S{2})");

--- a/test/Helper.hpp
+++ b/test/Helper.hpp
@@ -33,7 +33,7 @@
 
 #define syso(M) std::cout << M << std::endl;
 
-namespace testsuite
+namespace sctf
 {
 namespace util
 {
@@ -47,11 +47,6 @@ inline std::string serialize(const object::Aircraft::TargetType& crTargetType)
 
 namespace helper
 {
-PROVIDE_COMPARATOR(std::uint32_t, EQUALS, equalsUInt)
-PROVIDE_COMPARATOR(std::uint64_t, EQUALS, equalsULong)
-PROVIDE_COMPARATOR(double, EQUALS, equalsD)
-PROVIDE_COMPARATOR(std::string, EQUALS, equalsStr)
-PROVIDE_COMPARATOR(object::Aircraft::TargetType, EQUALS, equalsAtt)
 
 static boost::regex pflauRe("\\$PFLAU,,,,1,0,([-]?\\d+?),0,(\\d+?),(\\d+?),(\\S{6})\\*(?:\\S{2})");
 static boost::regex pflaaRe(

--- a/test/Helper.hpp
+++ b/test/Helper.hpp
@@ -47,12 +47,10 @@ inline std::string serialize(const object::Aircraft::TargetType& crTargetType)
 
 namespace helper
 {
-PROVIDE_COMPARATOR(std::int32_t, EQUALS, equalsInt)
 PROVIDE_COMPARATOR(std::uint32_t, EQUALS, equalsUInt)
 PROVIDE_COMPARATOR(std::uint64_t, EQUALS, equalsULong)
 PROVIDE_COMPARATOR(double, EQUALS, equalsD)
 PROVIDE_COMPARATOR(std::string, EQUALS, equalsStr)
-PROVIDE_COMPARATOR(bool, EQUALS, equalsBool)
 PROVIDE_COMPARATOR(object::Aircraft::TargetType, EQUALS, equalsAtt)
 
 static boost::regex pflauRe("\\$PFLAU,,,,1,0,([-]?\\d+?),0,(\\d+?),(\\d+?),(\\S{6})\\*(?:\\S{2})");

--- a/test/UnitTests.cpp
+++ b/test/UnitTests.cpp
@@ -19,10 +19,9 @@
  }
  */
 
-#include "framework/src/framework.h"
 #include "Helper.hpp"
 
-using namespace testsuite;
+using namespace sctf;
 
 TEST_FUNCTION(test_config)
 TEST_FUNCTION(test_data)
@@ -33,9 +32,9 @@ TEST_FUNCTION(test_math)
 
 int main(int, char**)
 {
-    //auto rep = reporter::createXmlReporter();
-    auto rep = reporter::createColoredReporter();
-    TestSuitesRunner runner;
+    // auto rep = createXmlReporter();
+    auto rep = createPlainTextReporter(true);
+    test::TestSuitesRunner runner;
 
     test_config(runner);
     test_data(runner);

--- a/test/UnitTests.cpp
+++ b/test/UnitTests.cpp
@@ -33,7 +33,8 @@ TEST_FUNCTION(test_math)
 
 int main(int, char**)
 {
-    auto rep = reporter::createXmlReporter();
+    //auto rep = reporter::createXmlReporter();
+    auto rep = reporter::createColoredReporter();
     TestSuitesRunner runner;
 
     test_config(runner);

--- a/test/UnitTests.cpp
+++ b/test/UnitTests.cpp
@@ -24,10 +24,6 @@
 
 using namespace testsuite;
 
-#ifdef assert
-#undef assert
-#endif
-
 TEST_FUNCTION(test_config)
 TEST_FUNCTION(test_data)
 TEST_FUNCTION(test_data_processor)

--- a/test/units/TestConfig.cpp
+++ b/test/units/TestConfig.cpp
@@ -71,15 +71,15 @@ void test_config(TestSuitesRunner& runner)
                 const auto feed_it = config.getFeedMapping().cbegin();
                 assertT(feed_it->first, SECT_KEY_ATMOS "1", helper::equalsStr, std::string);
                 assertT(feed_it->second.at(KV_KEY_PRIORITY), "1", helper::equalsStr, std::string);
-                assertT(config.getServerPort(), 1234, helper::equalsInt, int);
-                assert(config.getGroundMode(), true, helper::equalsBool);
+                assertT(config.getServerPort(), 1234, defaultEqualsInt, int);
+                assertTrue(config.getGroundMode());
                 assert(config.getPosition().getPosition().latitude, 77.777777, helper::equalsD);
                 assert(config.getPosition().getPosition().longitude, -12.121212, helper::equalsD);
-                assert(config.getPosition().getPosition().altitude, 1234, helper::equalsInt);
+                assert(config.getPosition().getPosition().altitude, 1234, defaultEqualsInt);
                 assert(config.getPosition().getGeoid(), 40.4, helper::equalsD);
                 assert(config.getAtmPressure(), 999.9, helper::equalsD);
-                assert(config.getMaxHeight(), INT32_MAX, helper::equalsInt);
-                assert(config.getMaxDistance(), 10000, helper::equalsInt);
+                assert(config.getMaxHeight(), INT32_MAX, defaultEqualsInt);
+                assert(config.getMaxDistance(), 10000, defaultEqualsInt);
             })
         ->test("only valid feeds", []() {
             std::stringstream conf_in;

--- a/test/units/TestConfig.cpp
+++ b/test/units/TestConfig.cpp
@@ -41,8 +41,8 @@ void test_config(TestSuitesRunner& runner)
 {
     describe<ConfigReader>("read config", runner)->test("read", []() {
         std::stringstream conf;
-        conf << "[" << SECT_KEY_FALLBACK << "]\n" << KV_KEY_LATITUDE << "   = 0.000000\n";
-        conf << KV_KEY_LONGITUDE << " = \n" << KV_KEY_ALTITUDE << "=1000; alt\n;ghsgd";
+        conf << "[" SECT_KEY_FALLBACK "]\n" << KV_KEY_LATITUDE "   = 0.000000\n";
+        conf << KV_KEY_LONGITUDE " = \n" << KV_KEY_ALTITUDE "=1000; alt\n;ghsgd";
         ConfigReader cr;
         PropertyMap map;
         cr.read(conf, map);
@@ -50,64 +50,56 @@ void test_config(TestSuitesRunner& runner)
                std::string("0.000000"), helper::equalsStr);
         assert(map.getProperty(SECT_KEY_FALLBACK, KV_KEY_LONGITUDE, "invalid"),
                std::string("invalid"), helper::equalsStr);
-        assert(map.getProperty(SECT_KEY_FALLBACK, KV_KEY_ALTITUDE, "invalid"),
-               std::string("1000"), helper::equalsStr);
-        assert(map.getProperty(SECT_KEY_FALLBACK, KV_KEY_GEOID, "invalid"),
-               std::string("invalid"), helper::equalsStr);
+        assert(map.getProperty(SECT_KEY_FALLBACK, KV_KEY_ALTITUDE, "invalid"), std::string("1000"),
+               helper::equalsStr);
+        assert(map.getProperty(SECT_KEY_FALLBACK, KV_KEY_GEOID, "invalid"), std::string("invalid"),
+               helper::equalsStr);
         assert(map.getProperty("nothing", ""), std::string(""), helper::equalsStr);
     });
 
     describe<Configuration>("initialize configuration", runner)
-        ->test("valid config - full, one feed",
-               []() {
-                   std::stringstream conf_in;
-                   conf_in << "[" << SECT_KEY_GENERAL << "]\n"
-                           << KV_KEY_FEEDS << "=sens1\n";
-                   conf_in << KV_KEY_SERVER_PORT << "=1234\n"
-                           << KV_KEY_GND_MODE << "=y\n";
-                   conf_in << "[" << SECT_KEY_FALLBACK << "]\n"
-                           << KV_KEY_LATITUDE << "=77.777777\n";
-                   conf_in << KV_KEY_LONGITUDE << "=-12.121212\n"
-                           << KV_KEY_ALTITUDE << "=1234\n";
-                   conf_in << KV_KEY_GEOID << "=40.4\n" << KV_KEY_PRESSURE << "=999.9\n";
-                   conf_in << "[" << SECT_KEY_FILTER << "]\n"
-                           << KV_KEY_MAX_HEIGHT << "=-1\n";
-                   conf_in << KV_KEY_MAX_DIST << "=10000\n";
-                   conf_in << "[sens1]\n" << KV_KEY_HOST << "=localhost\n";
-                   conf_in << KV_KEY_PORT << "=3456\n" << KV_KEY_PRIORITY << "=1\n";
-                   Configuration config(conf_in);
-                   const auto feed_it = config.getFeedMapping().cbegin();
-                   assert(feed_it->first, std::string("sens1"), helper::equalsStr);
-                   assert(feed_it->second.at(KV_KEY_PRIORITY), std::string("1"),
-                          helper::equalsStr);
-                   assert(static_cast<std::int32_t>(config.getServerPort()), 1234,
-                          helper::equalsInt);
-                   assert(config.getGroundMode(), true, helper::equalsBool);
-                   assert(config.getPosition().getPosition().latitude, 77.777777,
-                          helper::equalsD);
-                   assert(config.getPosition().getPosition().longitude, -12.121212,
-                          helper::equalsD);
-                   assert(config.getPosition().getPosition().altitude, 1234,
-                          helper::equalsInt);
-                   assert(config.getPosition().getGeoid(), 40.4, helper::equalsD);
-                   assert(config.getAtmPressure(), 999.9, helper::equalsD);
-                   assert(config.getMaxHeight(), INT32_MAX, helper::equalsInt);
-                   assert(config.getMaxDistance(), 10000, helper::equalsInt);
-               })
+        ->test(
+            "valid config - full, one feed",
+            []() {
+                std::stringstream conf_in;
+                conf_in << "[" SECT_KEY_GENERAL "]\n" << KV_KEY_FEEDS "=" SECT_KEY_ATMOS "1\n";
+                conf_in << KV_KEY_SERVER_PORT "=1234\n" << KV_KEY_GND_MODE "=y\n";
+                conf_in << "[" SECT_KEY_FALLBACK "]\n" << KV_KEY_LATITUDE "=77.777777\n";
+                conf_in << KV_KEY_LONGITUDE "=-12.121212\n" << KV_KEY_ALTITUDE "=1234\n";
+                conf_in << KV_KEY_GEOID "=40.4\n" << KV_KEY_PRESSURE "=999.9\n";
+                conf_in << "[" SECT_KEY_FILTER "]\n" << KV_KEY_MAX_HEIGHT "=-1\n";
+                conf_in << KV_KEY_MAX_DIST "=10000\n";
+                conf_in << "[" SECT_KEY_ATMOS "1]\n" << KV_KEY_HOST "=localhost\n";
+                conf_in << KV_KEY_PORT "=3456\n" << KV_KEY_PRIORITY "=1\n";
+                Configuration config(conf_in);
+                const auto feed_it = config.getFeedMapping().cbegin();
+                assert(feed_it->first, std::string(SECT_KEY_ATMOS "1"), helper::equalsStr);
+                assert(feed_it->second.at(KV_KEY_PRIORITY), std::string("1"), helper::equalsStr);
+                assert(static_cast<std::int32_t>(config.getServerPort()), 1234, helper::equalsInt);
+                assert(config.getGroundMode(), true, helper::equalsBool);
+                assert(config.getPosition().getPosition().latitude, 77.777777, helper::equalsD);
+                assert(config.getPosition().getPosition().longitude, -12.121212, helper::equalsD);
+                assert(config.getPosition().getPosition().altitude, 1234, helper::equalsInt);
+                assert(config.getPosition().getGeoid(), 40.4, helper::equalsD);
+                assert(config.getAtmPressure(), 999.9, helper::equalsD);
+                assert(config.getMaxHeight(), INT32_MAX, helper::equalsInt);
+                assert(config.getMaxDistance(), 10000, helper::equalsInt);
+            })
         ->test("only valid feeds", []() {
             std::stringstream conf_in;
-            conf_in << "[" << SECT_KEY_GENERAL << "]\n"
-                    << KV_KEY_FEEDS << "=sens,sbs1 , sbs2, else,,\n";
-            conf_in << "[sens]\n"
-                    << KV_KEY_HOST << "=127.0.0.1\n"
-                    << KV_KEY_PORT << "=3333\n"
-                    << KV_KEY_PRIORITY << "=0\n";
-            conf_in << "[sbs1]\n"
-                    << KV_KEY_HOST << "=127.0.0.1\n"
-                    << KV_KEY_PORT << "=3334\n"
-                    << KV_KEY_PRIORITY << "=1\n";
+            conf_in << "[" SECT_KEY_GENERAL "]\n"
+                    << KV_KEY_FEEDS "=" SECT_KEY_WIND "," SECT_KEY_SBS "1 , " SECT_KEY_SBS
+                                    "2, else,,\n";
+            conf_in << "[" SECT_KEY_WIND "]\n"
+                    << KV_KEY_HOST "=127.0.0.1\n"
+                    << KV_KEY_PORT "=3333\n"
+                    << KV_KEY_PRIORITY "=0\n";
+            conf_in << "[" SECT_KEY_SBS "1]\n"
+                    << KV_KEY_HOST "=127.0.0.1\n"
+                    << KV_KEY_PORT "=3334\n"
+                    << KV_KEY_PRIORITY "=1\n";
             Configuration config(conf_in);
-            std::string valid("sens,sbs1,");
+            std::string valid(SECT_KEY_WIND "," SECT_KEY_SBS "1,");
             std::string result;
             for(const auto& it : config.getFeedMapping())
             {

--- a/test/units/TestConfig.cpp
+++ b/test/units/TestConfig.cpp
@@ -27,11 +27,11 @@
 #include "../../src/config/Configuration.h"
 #include "../../src/config/PropertyMap.h"
 #include "../Helper.hpp"
-#include "../framework/src/framework.h"
 
 using namespace config;
-using namespace testsuite;
-using namespace comparator;
+using namespace sctf;
+using namespace test;
+using namespace comp;
 
 void test_config(TestSuitesRunner& runner)
 {
@@ -42,45 +42,44 @@ void test_config(TestSuitesRunner& runner)
         ConfigReader cr;
         PropertyMap map;
         cr.read(conf, map);
-        assertT(map.getProperty(SECT_KEY_FALLBACK, KV_KEY_LATITUDE, "invalid"), "0.000000",
-                helper::equalsStr, std::string);
-        assertT(map.getProperty(SECT_KEY_FALLBACK, KV_KEY_LONGITUDE, "invalid"), "invalid",
-                helper::equalsStr, std::string);
-        assertT(map.getProperty(SECT_KEY_FALLBACK, KV_KEY_ALTITUDE, "invalid"), "1000",
-                helper::equalsStr, std::string);
-        assertT(map.getProperty(SECT_KEY_FALLBACK, KV_KEY_GEOID, "invalid"), "invalid",
-                helper::equalsStr, std::string);
-        assertT(map.getProperty("nothing", ""), "", helper::equalsStr, std::string);
+        assertT(map.getProperty(SECT_KEY_FALLBACK, KV_KEY_LATITUDE, "invalid"), "0.000000", EQUALS,
+                std::string);
+        assertT(map.getProperty(SECT_KEY_FALLBACK, KV_KEY_LONGITUDE, "invalid"), "invalid", EQUALS,
+                std::string);
+        assertT(map.getProperty(SECT_KEY_FALLBACK, KV_KEY_ALTITUDE, "invalid"), "1000", EQUALS,
+                std::string);
+        assertT(map.getProperty(SECT_KEY_FALLBACK, KV_KEY_GEOID, "invalid"), "invalid", EQUALS,
+                std::string);
+        assertTrue(map.getProperty("nothing", "").empty());
     });
 
     describe<Configuration>("initialize configuration", runner)
-        ->test(
-            "valid config - full, one feed",
-            []() {
-                std::stringstream conf_in;
-                conf_in << "[" SECT_KEY_GENERAL "]\n" << KV_KEY_FEEDS "=" SECT_KEY_ATMOS "1\n";
-                conf_in << KV_KEY_SERVER_PORT "=1234\n" << KV_KEY_GND_MODE "=y\n";
-                conf_in << "[" SECT_KEY_FALLBACK "]\n" << KV_KEY_LATITUDE "=77.777777\n";
-                conf_in << KV_KEY_LONGITUDE "=-12.121212\n" << KV_KEY_ALTITUDE "=1234\n";
-                conf_in << KV_KEY_GEOID "=40.4\n" << KV_KEY_PRESSURE "=999.9\n";
-                conf_in << "[" SECT_KEY_FILTER "]\n" << KV_KEY_MAX_HEIGHT "=-1\n";
-                conf_in << KV_KEY_MAX_DIST "=10000\n";
-                conf_in << "[" SECT_KEY_ATMOS "1]\n" << KV_KEY_HOST "=localhost\n";
-                conf_in << KV_KEY_PORT "=3456\n" << KV_KEY_PRIORITY "=1\n";
-                Configuration config(conf_in);
-                const auto feed_it = config.getFeedMapping().cbegin();
-                assertT(feed_it->first, SECT_KEY_ATMOS "1", helper::equalsStr, std::string);
-                assertT(feed_it->second.at(KV_KEY_PRIORITY), "1", helper::equalsStr, std::string);
-                assertT(config.getServerPort(), 1234, defaultEqualsInt, int);
-                assertTrue(config.getGroundMode());
-                assert(config.getPosition().getPosition().latitude, 77.777777, helper::equalsD);
-                assert(config.getPosition().getPosition().longitude, -12.121212, helper::equalsD);
-                assert(config.getPosition().getPosition().altitude, 1234, defaultEqualsInt);
-                assert(config.getPosition().getGeoid(), 40.4, helper::equalsD);
-                assert(config.getAtmPressure(), 999.9, helper::equalsD);
-                assert(config.getMaxHeight(), INT32_MAX, defaultEqualsInt);
-                assert(config.getMaxDistance(), 10000, defaultEqualsInt);
-            })
+        ->test("valid config - full, one feed",
+               []() {
+                   std::stringstream conf_in;
+                   conf_in << "[" SECT_KEY_GENERAL "]\n" << KV_KEY_FEEDS "=" SECT_KEY_ATMOS "1\n";
+                   conf_in << KV_KEY_SERVER_PORT "=1234\n" << KV_KEY_GND_MODE "=y\n";
+                   conf_in << "[" SECT_KEY_FALLBACK "]\n" << KV_KEY_LATITUDE "=77.777777\n";
+                   conf_in << KV_KEY_LONGITUDE "=-12.121212\n" << KV_KEY_ALTITUDE "=1234\n";
+                   conf_in << KV_KEY_GEOID "=40.4\n" << KV_KEY_PRESSURE "=999.9\n";
+                   conf_in << "[" SECT_KEY_FILTER "]\n" << KV_KEY_MAX_HEIGHT "=-1\n";
+                   conf_in << KV_KEY_MAX_DIST "=10000\n";
+                   conf_in << "[" SECT_KEY_ATMOS "1]\n" << KV_KEY_HOST "=localhost\n";
+                   conf_in << KV_KEY_PORT "=3456\n" << KV_KEY_PRIORITY "=1\n";
+                   Configuration config(conf_in);
+                   const auto feed_it = config.getFeedMapping().cbegin();
+                   assertT(feed_it->first, SECT_KEY_ATMOS "1", EQUALS, std::string);
+                   assertT(feed_it->second.at(KV_KEY_PRIORITY), "1", EQUALS, std::string);
+                   assertT(config.getServerPort(), 1234, EQUALS, int);
+                   assertTrue(config.getGroundMode());
+                   assertEquals(config.getPosition().getPosition().latitude, 77.777777);
+                   assertEquals(config.getPosition().getPosition().longitude, -12.121212);
+                   assertEquals(config.getPosition().getPosition().altitude, 1234);
+                   assertEquals(config.getPosition().getGeoid(), 40.4);
+                   assertEquals(config.getAtmPressure(), 999.9);
+                   assertEquals(config.getMaxHeight(), INT32_MAX);
+                   assertEquals(config.getMaxDistance(), 10000);
+               })
         ->test("only valid feeds", []() {
             std::stringstream conf_in;
             conf_in << "[" SECT_KEY_GENERAL "]\n"
@@ -101,6 +100,6 @@ void test_config(TestSuitesRunner& runner)
             {
                 result += it.first + ",";
             }
-            assert(result, valid, helper::equalsStr);
+            assertEquals(result, valid);
         });
 }

--- a/test/units/TestConfig.cpp
+++ b/test/units/TestConfig.cpp
@@ -30,10 +30,8 @@
 
 using namespace config;
 using namespace sctf;
-using namespace test;
-using namespace comp;
 
-void test_config(TestSuitesRunner& runner)
+void test_config(test::TestSuitesRunner& runner)
 {
     describe<ConfigReader>("read config", runner)->test("read", []() {
         std::stringstream conf;
@@ -42,14 +40,10 @@ void test_config(TestSuitesRunner& runner)
         ConfigReader cr;
         PropertyMap map;
         cr.read(conf, map);
-        assertT(map.getProperty(SECT_KEY_FALLBACK, KV_KEY_LATITUDE, "invalid"), "0.000000", EQUALS,
-                std::string);
-        assertT(map.getProperty(SECT_KEY_FALLBACK, KV_KEY_LONGITUDE, "invalid"), "invalid", EQUALS,
-                std::string);
-        assertT(map.getProperty(SECT_KEY_FALLBACK, KV_KEY_ALTITUDE, "invalid"), "1000", EQUALS,
-                std::string);
-        assertT(map.getProperty(SECT_KEY_FALLBACK, KV_KEY_GEOID, "invalid"), "invalid", EQUALS,
-                std::string);
+        assertEqStr(map.getProperty(SECT_KEY_FALLBACK, KV_KEY_LATITUDE, "invalid"), "0.000000");
+        assertEqStr(map.getProperty(SECT_KEY_FALLBACK, KV_KEY_LONGITUDE, "invalid"), "invalid");
+        assertEqStr(map.getProperty(SECT_KEY_FALLBACK, KV_KEY_ALTITUDE, "invalid"), "1000");
+        assertEqStr(map.getProperty(SECT_KEY_FALLBACK, KV_KEY_GEOID, "invalid"), "invalid");
         assertTrue(map.getProperty("nothing", "").empty());
     });
 
@@ -68,9 +62,9 @@ void test_config(TestSuitesRunner& runner)
                    conf_in << KV_KEY_PORT "=3456\n" << KV_KEY_PRIORITY "=1\n";
                    Configuration config(conf_in);
                    const auto feed_it = config.getFeedMapping().cbegin();
-                   assertT(feed_it->first, SECT_KEY_ATMOS "1", EQUALS, std::string);
-                   assertT(feed_it->second.at(KV_KEY_PRIORITY), "1", EQUALS, std::string);
-                   assertT(config.getServerPort(), 1234, EQUALS, int);
+                   assertEqStr(feed_it->first, SECT_KEY_ATMOS "1");
+                   assertEqStr(feed_it->second.at(KV_KEY_PRIORITY), "1");
+                   assertT(config.getServerPort(), EQUALS, 1234, int);
                    assertTrue(config.getGroundMode());
                    assertEquals(config.getPosition().getPosition().latitude, 77.777777);
                    assertEquals(config.getPosition().getPosition().longitude, -12.121212);

--- a/test/units/TestConfig.cpp
+++ b/test/units/TestConfig.cpp
@@ -29,10 +29,6 @@
 #include "../Helper.hpp"
 #include "../framework/src/framework.h"
 
-#ifdef assert
-#undef assert
-#endif
-
 using namespace config;
 using namespace testsuite;
 using namespace comparator;
@@ -46,15 +42,15 @@ void test_config(TestSuitesRunner& runner)
         ConfigReader cr;
         PropertyMap map;
         cr.read(conf, map);
-        assert(map.getProperty(SECT_KEY_FALLBACK, KV_KEY_LATITUDE, "invalid"),
-               std::string("0.000000"), helper::equalsStr);
-        assert(map.getProperty(SECT_KEY_FALLBACK, KV_KEY_LONGITUDE, "invalid"),
-               std::string("invalid"), helper::equalsStr);
-        assert(map.getProperty(SECT_KEY_FALLBACK, KV_KEY_ALTITUDE, "invalid"), std::string("1000"),
-               helper::equalsStr);
-        assert(map.getProperty(SECT_KEY_FALLBACK, KV_KEY_GEOID, "invalid"), std::string("invalid"),
-               helper::equalsStr);
-        assert(map.getProperty("nothing", ""), std::string(""), helper::equalsStr);
+        assertT(map.getProperty(SECT_KEY_FALLBACK, KV_KEY_LATITUDE, "invalid"), "0.000000",
+                helper::equalsStr, std::string);
+        assertT(map.getProperty(SECT_KEY_FALLBACK, KV_KEY_LONGITUDE, "invalid"), "invalid",
+                helper::equalsStr, std::string);
+        assertT(map.getProperty(SECT_KEY_FALLBACK, KV_KEY_ALTITUDE, "invalid"), "1000",
+                helper::equalsStr, std::string);
+        assertT(map.getProperty(SECT_KEY_FALLBACK, KV_KEY_GEOID, "invalid"), "invalid",
+                helper::equalsStr, std::string);
+        assertT(map.getProperty("nothing", ""), "", helper::equalsStr, std::string);
     });
 
     describe<Configuration>("initialize configuration", runner)
@@ -73,9 +69,9 @@ void test_config(TestSuitesRunner& runner)
                 conf_in << KV_KEY_PORT "=3456\n" << KV_KEY_PRIORITY "=1\n";
                 Configuration config(conf_in);
                 const auto feed_it = config.getFeedMapping().cbegin();
-                assert(feed_it->first, std::string(SECT_KEY_ATMOS "1"), helper::equalsStr);
-                assert(feed_it->second.at(KV_KEY_PRIORITY), std::string("1"), helper::equalsStr);
-                assert(static_cast<std::int32_t>(config.getServerPort()), 1234, helper::equalsInt);
+                assertT(feed_it->first, SECT_KEY_ATMOS "1", helper::equalsStr, std::string);
+                assertT(feed_it->second.at(KV_KEY_PRIORITY), "1", helper::equalsStr, std::string);
+                assertT(config.getServerPort(), 1234, helper::equalsInt, int);
                 assert(config.getGroundMode(), true, helper::equalsBool);
                 assert(config.getPosition().getPosition().latitude, 77.777777, helper::equalsD);
                 assert(config.getPosition().getPosition().longitude, -12.121212, helper::equalsD);

--- a/test/units/TestData.cpp
+++ b/test/units/TestData.cpp
@@ -32,10 +32,8 @@
 
 using namespace data;
 using namespace sctf;
-using namespace test;
-using namespace comp;
 
-void test_data(TestSuitesRunner& runner)
+void test_data(test::TestSuitesRunner& runner)
 {
     describe<AircraftData>("Container functions", runner)
         ->test(
@@ -102,7 +100,7 @@ void test_data(TestSuitesRunner& runner)
                 std::string proc = data.getSerialized();
                 bool matched     = boost::regex_search(proc, match, helper::pflauRe);
                 assertTrue(matched);
-                assertT(match.str(2), "610", EQUALS, std::string);
+                assertStr(match.str(2), "610", EQUALS);
                 for(int i = 0; i < AC_NO_FLARM_THRESHOLD; ++i)
                 {
                     data.processAircrafts(pos, press);
@@ -115,7 +113,7 @@ void test_data(TestSuitesRunner& runner)
                 proc    = data.getSerialized();
                 matched = boost::regex_search(proc, match, helper::pflauRe);
                 assertTrue(matched);
-                assertT(match.str(2), "1000", EQUALS, std::string);
+                assertStr(match.str(2), "1000", EQUALS);
             })
         ->test("write after outdated", []() {
             feed::parser::AprsParser aprsParser;
@@ -139,7 +137,7 @@ void test_data(TestSuitesRunner& runner)
                 std::string proc = data.getSerialized();
                 boost::smatch match;
                 assertTrue(boost::regex_search(proc, match, helper::pflauRe));
-                assertT(match.str(2), "610", EQUALS, std::string);
+                assertStr(match.str(2), "610", EQUALS);
             }
             data.processAircrafts(pos, press);
             assertZero(data.getSerialized().size());
@@ -148,7 +146,7 @@ void test_data(TestSuitesRunner& runner)
             std::string proc = data.getSerialized();
             boost::smatch match;
             assertTrue(boost::regex_search(proc, match, helper::pflauRe));
-            assertT(match.str(2), "305", EQUALS, std::string);
+            assertStr(match.str(2), "305", EQUALS);
         });
 
     describeParallel<GpsData>("gps string", runner)
@@ -159,8 +157,8 @@ void test_data(TestSuitesRunner& runner)
                    pos.setTimeStamp(object::TimeStamp("000001", object::TimeStamp::Format::HHMMSS));
                    data.update(std::move(pos));
                    assertEquals(data.getPosition().latitude, 10.0);
-                   assert(data.getPosition().longitude, 85.0, helper::equalsD);
-                   assert(data.getPosition().altitude, 100, defaultEqualsInt);
+                   assertEquals(data.getPosition().longitude, 85.0);
+                   assertEquals(data.getPosition().altitude, 100);
                    std::string fix = data.getSerialized();
                    boost::smatch match;
                    bool matched = boost::regex_search(fix, match, helper::gpsRe);
@@ -176,12 +174,12 @@ void test_data(TestSuitesRunner& runner)
                 pos1.setPosition({0.0, 0.0, 2000});
                 pos1.setTimeStamp(object::TimeStamp("000001", object::TimeStamp::Format::HHMMSS));
                 assertTrue(data.update(std::move(pos0)));
-                assert(data.getPosition().altitude, 1000, defaultEqualsInt);
+                assertEquals(data.getPosition().altitude, 1000);
                 data.update(std::move(pos1));
-                assert(data.getPosition().altitude, 2000, defaultEqualsInt);
+                assertEquals(data.getPosition().altitude, 2000);
                 pos0.setTimeStamp(object::TimeStamp("000002", object::TimeStamp::Format::HHMMSS));
                 data.update(std::move(pos0));
-                assert(data.getPosition().altitude, 2000, defaultEqualsInt);
+                assertEquals(data.getPosition().altitude, 2000);
             })
         ->test("write after outdated", []() {
             GpsData data;
@@ -190,18 +188,18 @@ void test_data(TestSuitesRunner& runner)
             pos1.setPosition({0.0, 0.0, 1000});
             pos2.setPosition({0.0, 0.0, 2000});
             pos1.setTimeStamp(object::TimeStamp("000001", object::TimeStamp::Format::HHMMSS));
-            assert(data.update(std::move(pos2)), true, helper::equalsBool);
-            assert(data.getPosition().altitude, 2000, helper::equalsInt);
+            assertTrue(data.update(std::move(pos2)));
+            assertEquals(data.getPosition().altitude, 2000);
 
             for(int i = 0; i < OBJ_OUTDATED - 1; ++i)
             {
-                assert(data.update(std::move(pos1)), false, helper::equalsBool);
-                assert(data.getPosition().altitude, 2000, helper::equalsInt);
+                assertFalse(data.update(std::move(pos1)));
+                assertEquals(data.getPosition().altitude, 2000);
                 data.getSerialized();
             }
             data.getSerialized();
-            assert(data.update(std::move(pos1)), true, helper::equalsBool);
-            assert(data.getPosition().altitude, 1000, helper::equalsInt);
+            assertTrue(data.update(std::move(pos1)));
+            assertEquals(data.getPosition().altitude, 1000);
         });
 
     describeParallel<WindData>("wind data", runner)
@@ -211,9 +209,8 @@ void test_data(TestSuitesRunner& runner)
                    object::Wind wind;
                    wind.setSerialized("$WIMWV,242.8,R,6.9,N,A*20\r\n");
                    data.update(std::move(wind));
-                   assertT(data.getSerialized(), "$WIMWV,242.8,R,6.9,N,A*20\r\n", EQUALS,
-                           std::string);
-                   assertT(data.getSerialized(), "", EQUALS, std::string);
+                   assertStr(data.getSerialized(), "$WIMWV,242.8,R,6.9,N,A*20\r\n", EQUALS);
+                   assertStr(data.getSerialized(), "", EQUALS);
                })
         ->test("write higher priority",
                []() {
@@ -222,11 +219,11 @@ void test_data(TestSuitesRunner& runner)
                    object::Wind wind1(1);
                    wind0.setSerialized("$WIMWV,242.8,R,6.9,N,A*20\r\n");
                    wind1.setSerialized("updated");
-                   assert(data.update(std::move(wind0)), true, helper::equalsBool);
-                   assert(data.update(std::move(wind1)), true, helper::equalsBool);
-                   assertT(data.getSerialized(), "updated", EQUALS, std::string);
+                   assertTrue(data.update(std::move(wind0)));
+                   assertTrue(data.update(std::move(wind1)));
+                   assertStr(data.getSerialized(), "updated", EQUALS);
                    wind0.setSerialized("$WIMWV,242.8,R,6.9,N,A*20\r\n");
-                   assert(data.update(std::move(wind0)), false, helper::equalsBool);
+                   assertFalse(data.update(std::move(wind0)));
                })
         ->test("write after attempt", []() {
             WindData data;
@@ -235,11 +232,11 @@ void test_data(TestSuitesRunner& runner)
             wind1.setSerialized("lower");
             wind2.setSerialized("higher");
             data.update(std::move(wind2));
-            assertT(data.getSerialized(), "higher", EQUALS, std::string);
+            assertStr(data.getSerialized(), "higher", EQUALS);
             data.update(std::move(wind1));
-            assertT(data.getSerialized(), "", EQUALS, std::string);
+            assertStr(data.getSerialized(), "", EQUALS);
             data.update(std::move(wind1));
-            assertT(data.getSerialized(), "lower", EQUALS, std::string);
+            assertStr(data.getSerialized(), "lower", EQUALS);
         });
 
     describeParallel<AtmosphereData>("atmosphere data", runner)
@@ -250,10 +247,9 @@ void test_data(TestSuitesRunner& runner)
                    atm.setPressure(1009.1);
                    atm.setSerialized("$WIMDA,29.7987,I,1.0091,B,14.8,C,,,,,,,,,,,,,,*3E\r\n");
                    data.update(std::move(atm));
-                   assertT(data.getSerialized(),
-                           "$WIMDA,29.7987,I,1.0091,B,14.8,C,,,,,,,,,,,,,,*3E\r\n", EQUALS,
-                           std::string);
-                   assert(data.getAtmPressure(), 1009.1, helper::equalsD);
+                   assertStr(data.getSerialized(),
+                             "$WIMDA,29.7987,I,1.0091,B,14.8,C,,,,,,,,,,,,,,*3E\r\n", EQUALS);
+                   assertEquals(data.getAtmPressure(), 1009.1);
                })
         ->test("write higher priority",
                []() {
@@ -263,9 +259,9 @@ void test_data(TestSuitesRunner& runner)
                    atm0.setPressure(1009.1);
                    atm1.setPressure(900.0);
                    data.update(std::move(atm0));
-                   assert(data.getAtmPressure(), 1009.1, helper::equalsD);
+                   assertEquals(data.getAtmPressure(), 1009.1);
                    data.update(std::move(atm1));
-                   assert(data.getAtmPressure(), 900.0, helper::equalsD);
+                   assertEquals(data.getAtmPressure(), 900.0);
                })
         ->test("write after attempt", []() {
             AtmosphereData data;
@@ -274,10 +270,10 @@ void test_data(TestSuitesRunner& runner)
             atm1.setPressure(1009.1);
             atm2.setPressure(900.0);
             data.update(std::move(atm2));
-            assert(data.getAtmPressure(), 900.0, helper::equalsD);
+            assertEquals(data.getAtmPressure(), 900.0);
             data.update(std::move(atm1));
-            assert(data.getAtmPressure(), 900.0, helper::equalsD);
+            assertEquals(data.getAtmPressure(), 900.0);
             data.update(std::move(atm1));
-            assert(data.getAtmPressure(), 1009.1, helper::equalsD);
+            assertEquals(data.getAtmPressure(), 1009.1);
         });
 }

--- a/test/units/TestData.cpp
+++ b/test/units/TestData.cpp
@@ -49,13 +49,12 @@ void test_data(TestSuitesRunner& runner)
                 AircraftData data;
                 object::Aircraft ac;
                 object::Position pos{49.0, 8.0, 0};
-                double press     = 1013.25;
-                std::size_t slot = data.registerSlot();
+                double press = 1013.25;
                 sbsParser.unpack(
                     "MSG,3,0,0,BBBBBB,0,2017/02/16,20:11:30.772,2017/02/16,20:11:30.772,,3281,,,49.000000,8.000000,,,,,,0",
                     ac);
-                data.update(std::move(ac), slot);
-                for(int i = 0; i < AC_OUTDATED; ++i)
+                data.update(std::move(ac));
+                for(int i = 0; i < OBJ_OUTDATED; ++i)
                 {
                     data.processAircrafts(pos, press);
                 }
@@ -68,12 +67,11 @@ void test_data(TestSuitesRunner& runner)
                 AircraftData data;
                 object::Aircraft ac;
                 object::Position pos{49.0, 8.0, 0};
-                double press     = 1013.25;
-                std::size_t slot = data.registerSlot();
+                double press = 1013.25;
                 sbsParser.unpack(
                     "MSG,3,0,0,BBBBBB,0,2017/02/16,20:11:30.772,2017/02/16,20:11:30.772,,3281,,,49.000000,8.000000,,,,,,0",
                     ac);
-                data.update(std::move(ac), slot);
+                data.update(std::move(ac));
                 for(int i = 0; i < AC_DELETE_THRESHOLD; ++i)
                 {
                     data.processAircrafts(pos, press);
@@ -88,23 +86,22 @@ void test_data(TestSuitesRunner& runner)
                 boost::smatch match;
                 object::Aircraft ac;
                 object::Position pos{49.0, 8.0, 0};
-                double press     = 1013.25;
-                std::size_t slot = data.registerSlot();
+                double press = 1013.25;
 
                 sbsParser.unpack(
                     "MSG,3,0,0,BBBBBB,0,2017/02/16,20:11:30.772,2017/02/16,20:11:30.772,,3281,,,49.000000,8.000000,,,,,,0",
                     ac);
-                data.update(std::move(ac), slot);
+                data.update(std::move(ac));
                 data.processAircrafts(pos, press);
                 aprsParser.unpack(
                     "FLRBBBBBB>APRS,qAS,XXXX:/201131h4900.00N/00800.00E'180/090/A=002000 id0ABBBBBB +010fpm +0.3rot",
                     ac);
-                data.update(std::move(ac), slot);
+                data.update(std::move(ac));
                 data.processAircrafts(pos, press);
                 sbsParser.unpack(
                     "MSG,3,0,0,BBBBBB,0,2017/02/16,20:11:32.000,2017/02/16,20:11:32.000,,3281,,,49.000000,8.000000,,,,,,0",
                     ac);
-                data.update(std::move(ac), slot);
+                data.update(std::move(ac));
                 data.processAircrafts(pos, press);
                 std::string proc = data.getSerialized();
                 bool matched     = boost::regex_search(proc, match, helper::pflauRe);
@@ -117,7 +114,7 @@ void test_data(TestSuitesRunner& runner)
                 sbsParser.unpack(
                     "MSG,3,0,0,BBBBBB,0,2017/02/16,20:11:33.000,2017/02/16,20:11:33.000,,3281,,,49.000000,8.000000,,,,,,0",
                     ac);
-                data.update(std::move(ac), slot);
+                data.update(std::move(ac));
                 data.processAircrafts(pos, press);
                 proc    = data.getSerialized();
                 matched = boost::regex_search(proc, match, helper::pflauRe);
@@ -132,26 +129,23 @@ void test_data(TestSuitesRunner& runner)
             object::Position pos{49.0, 8.0, 0};
             double press = 1013.25;
             boost::smatch match;
-            std::size_t slot = data.registerSlot();
             aprsParser.unpack(
                 "FLRBBBBBB>APRS,qAS,XXXX:/201131h4900.00N/00800.00E'180/090/A=002000 id0ABBBBBB +010fpm +0.3rot",
                 ac2);
             aprsParser.unpack(
                 "FLRBBBBBB>APRS,qAS,XXXX:/201131h4900.00N/00800.00E'180/090/A=001000 id0ABBBBBB +010fpm +0.3rot",
                 ac1);
-            assert(data.update(std::move(ac2), slot), true, helper::equalsBool);
-            assert(data.update(std::move(ac1), slot), false, helper::equalsBool);
+            assert(data.update(std::move(ac2)), true, helper::equalsBool);
+            assert(data.update(std::move(ac1)), false, helper::equalsBool);
             data.processAircrafts(pos, press);
             std::string proc = data.getSerialized();
-            assert(boost::regex_search(proc, match, helper::pflauRe), true,
-                   helper::equalsBool);
+            assert(boost::regex_search(proc, match, helper::pflauRe), true, helper::equalsBool);
             assert(match.str(2), std::string("610"), helper::equalsStr);
 
-            assert(data.update(std::move(ac1), slot), true, helper::equalsBool);
+            assert(data.update(std::move(ac1)), true, helper::equalsBool);
             data.processAircrafts(pos, press);
             proc = data.getSerialized();
-            assert(boost::regex_search(proc, match, helper::pflauRe), true,
-                   helper::equalsBool);
+            assert(boost::regex_search(proc, match, helper::pflauRe), true, helper::equalsBool);
             assert(match.str(2), std::string("305"), helper::equalsStr);
         });
 
@@ -159,9 +153,8 @@ void test_data(TestSuitesRunner& runner)
         ->test("correct gps position",
                []() {
                    GpsData data;
-                   std::size_t slot = data.registerSlot();
                    object::GpsPosition pos({10.0, 85.0, 100}, 40.0);
-                   data.update(std::move(pos), slot);
+                   data.update(std::move(pos));
                    assert(data.getPosition().latitude, 10.0, helper::equalsD);
                    assert(data.getPosition().longitude, 85.0, helper::equalsD);
                    assert(data.getPosition().altitude, 100, helper::equalsInt);
@@ -173,30 +166,28 @@ void test_data(TestSuitesRunner& runner)
         ->test("write higher priority",
                []() {
                    GpsData data;
-                   std::size_t slot = data.registerSlot();
                    object::GpsPosition pos0(0);
                    object::GpsPosition pos1(1);
                    pos0.setPosition({0.0, 0.0, 1000});
                    pos1.setPosition({0.0, 0.0, 2000});
-                   data.update(std::move(pos0), slot);
+                   data.update(std::move(pos0));
                    assert(data.getPosition().altitude, 1000, helper::equalsInt);
-                   data.update(std::move(pos1), slot);
+                   data.update(std::move(pos1));
                    assert(data.getPosition().altitude, 2000, helper::equalsInt);
-                   data.update(std::move(pos0), slot);
+                   data.update(std::move(pos0));
                    assert(data.getPosition().altitude, 2000, helper::equalsInt);
                })
         ->test("write after attempts", []() {
             GpsData data;
-            std::size_t slot = data.registerSlot();
             object::GpsPosition pos1(1);
             object::GpsPosition pos2(2);
             pos1.setPosition({0.0, 0.0, 1000});
             pos2.setPosition({0.0, 0.0, 2000});
-            data.update(std::move(pos2), slot);
+            data.update(std::move(pos2));
             assert(data.getPosition().altitude, 2000, helper::equalsInt);
-            data.update(std::move(pos1), slot);
+            data.update(std::move(pos1));
             assert(data.getPosition().altitude, 2000, helper::equalsInt);
-            data.update(std::move(pos1), slot);
+            data.update(std::move(pos1));
             assert(data.getPosition().altitude, 1000, helper::equalsInt);
         });
 
@@ -205,11 +196,9 @@ void test_data(TestSuitesRunner& runner)
                []() {
                    WindData data;
                    object::Wind wind;
-                   std::size_t slot = data.registerSlot();
                    wind.setSerialized("$WIMWV,242.8,R,6.9,N,A*20\r\n");
-                   data.update(std::move(wind), slot);
-                   assert(data.getSerialized(),
-                          std::string("$WIMWV,242.8,R,6.9,N,A*20\r\n"),
+                   data.update(std::move(wind));
+                   assert(data.getSerialized(), std::string("$WIMWV,242.8,R,6.9,N,A*20\r\n"),
                           helper::equalsStr);
                    assert(data.getSerialized(), std::string(""), helper::equalsStr);
                })
@@ -218,28 +207,25 @@ void test_data(TestSuitesRunner& runner)
                    WindData data;
                    object::Wind wind0(0);
                    object::Wind wind1(1);
-                   std::size_t slot = data.registerSlot();
                    wind0.setSerialized("$WIMWV,242.8,R,6.9,N,A*20\r\n");
                    wind1.setSerialized("updated");
-                   assert(data.update(std::move(wind0), slot), true, helper::equalsBool);
-                   assert(data.update(std::move(wind1), slot), true, helper::equalsBool);
-                   assert(data.getSerialized(), std::string("updated"),
-                          helper::equalsStr);
+                   assert(data.update(std::move(wind0)), true, helper::equalsBool);
+                   assert(data.update(std::move(wind1)), true, helper::equalsBool);
+                   assert(data.getSerialized(), std::string("updated"), helper::equalsStr);
                    wind0.setSerialized("$WIMWV,242.8,R,6.9,N,A*20\r\n");
-                   assert(data.update(std::move(wind0), slot), false, helper::equalsBool);
+                   assert(data.update(std::move(wind0)), false, helper::equalsBool);
                })
         ->test("write after attempt", []() {
             WindData data;
             object::Wind wind1(1);
             object::Wind wind2(2);
-            std::size_t slot = data.registerSlot();
             wind1.setSerialized("lower");
             wind2.setSerialized("higher");
-            data.update(std::move(wind2), slot);
+            data.update(std::move(wind2));
             assert(data.getSerialized(), std::string("higher"), helper::equalsStr);
-            data.update(std::move(wind1), slot);
+            data.update(std::move(wind1));
             assert(data.getSerialized(), std::string(""), helper::equalsStr);
-            data.update(std::move(wind1), slot);
+            data.update(std::move(wind1));
             assert(data.getSerialized(), std::string("lower"), helper::equalsStr);
         });
 
@@ -248,14 +234,11 @@ void test_data(TestSuitesRunner& runner)
                []() {
                    AtmosphereData data;
                    object::Atmosphere atm;
-                   std::size_t slot = data.registerSlot();
                    atm.setPressure(1009.1);
-                   atm.setSerialized(
-                       "$WIMDA,29.7987,I,1.0091,B,14.8,C,,,,,,,,,,,,,,*3E\r\n");
-                   data.update(std::move(atm), slot);
+                   atm.setSerialized("$WIMDA,29.7987,I,1.0091,B,14.8,C,,,,,,,,,,,,,,*3E\r\n");
+                   data.update(std::move(atm));
                    assert(data.getSerialized(),
-                          std::string(
-                              "$WIMDA,29.7987,I,1.0091,B,14.8,C,,,,,,,,,,,,,,*3E\r\n"),
+                          std::string("$WIMDA,29.7987,I,1.0091,B,14.8,C,,,,,,,,,,,,,,*3E\r\n"),
                           helper::equalsStr);
                    assert(data.getAtmPressure(), 1009.1, helper::equalsD);
                })
@@ -264,26 +247,24 @@ void test_data(TestSuitesRunner& runner)
                    AtmosphereData data;
                    object::Atmosphere atm0(0);
                    object::Atmosphere atm1(1);
-                   std::size_t slot = data.registerSlot();
                    atm0.setPressure(1009.1);
                    atm1.setPressure(900.0);
-                   data.update(std::move(atm0), slot);
+                   data.update(std::move(atm0));
                    assert(data.getAtmPressure(), 1009.1, helper::equalsD);
-                   data.update(std::move(atm1), slot);
+                   data.update(std::move(atm1));
                    assert(data.getAtmPressure(), 900.0, helper::equalsD);
                })
         ->test("write after attempt", []() {
             AtmosphereData data;
             object::Atmosphere atm1(1);
             object::Atmosphere atm2(2);
-            std::size_t slot = data.registerSlot();
             atm1.setPressure(1009.1);
             atm2.setPressure(900.0);
-            data.update(std::move(atm2), slot);
+            data.update(std::move(atm2));
             assert(data.getAtmPressure(), 900.0, helper::equalsD);
-            data.update(std::move(atm1), slot);
+            data.update(std::move(atm1));
             assert(data.getAtmPressure(), 900.0, helper::equalsD);
-            data.update(std::move(atm1), slot);
+            data.update(std::move(atm1));
             assert(data.getAtmPressure(), 1009.1, helper::equalsD);
         });
 }

--- a/test/units/TestDataProcessor.cpp
+++ b/test/units/TestDataProcessor.cpp
@@ -24,10 +24,6 @@
 #include "../Helper.hpp"
 #include "../framework/src/framework.h"
 
-#ifdef assert
-#undef assert
-#endif
-
 using namespace data::processor;
 using namespace object;
 using namespace testsuite;

--- a/test/units/TestDataProcessor.cpp
+++ b/test/units/TestDataProcessor.cpp
@@ -22,14 +22,12 @@
 #include "../../src/data/processor/AircraftProcessor.h"
 #include "../../src/data/processor/GpsProcessor.h"
 #include "../Helper.hpp"
-#include "../framework/src/framework.h"
 
 using namespace data::processor;
 using namespace object;
-using namespace testsuite;
-using namespace comparator;
+using namespace sctf;
 
-void test_data_processor(TestSuitesRunner& runner)
+void test_data_processor(test::TestSuitesRunner& runner)
 {
     describe<GpsProcessor>("Process GPS data", runner)->test("process", []() {
         GpsProcessor gpsp;
@@ -37,7 +35,7 @@ void test_data_processor(TestSuitesRunner& runner)
         GpsPosition pos({0.0, 0.0, 0}, 48.0);
         gpsp.process(pos);
         bool matched = boost::regex_search(pos.getSerialized(), match, helper::gpsRe);
-        assert(matched, true, helper::equalsBool);
+        assertTrue(matched);
     });
 
     describe<AircraftProcessor>("Process Aircrafts", runner)
@@ -52,21 +50,19 @@ void test_data_processor(TestSuitesRunner& runner)
                    proc.setRefered({49.0, 8.0, 0}, 1013.25);
                    proc.process(ac);
                    boost::smatch match;
-                   bool matched
-                       = boost::regex_search(ac.getSerialized(), match, helper::pflauRe);
-                   assert(matched, true, helper::equalsBool);
-                   assert(match.str(1), std::string("0"), helper::equalsStr);
-                   assert(match.str(2), std::string("1000"), helper::equalsStr);
-                   assert(match.str(3), std::string("0"), helper::equalsStr);
-                   assert(match.str(4), std::string("BBBBBB"), helper::equalsStr);
-                   matched
-                       = boost::regex_search(ac.getSerialized(), match, helper::pflaaRe);
-                   assert(matched, true, helper::equalsBool);
-                   assert(match.str(1), std::string("0"), helper::equalsStr);
-                   assert(match.str(2), std::string("0"), helper::equalsStr);
-                   assert(match.str(3), std::string("1000"), helper::equalsStr);
-                   assert(match.str(5), std::string("BBBBBB"), helper::equalsStr);
-                   assert(match.str(9), std::string("8"), helper::equalsStr);
+                   bool matched = boost::regex_search(ac.getSerialized(), match, helper::pflauRe);
+                   assertTrue(matched);
+                   assertEqStr(match.str(1), "0");
+                   assertEqStr(match.str(2), "1000");
+                   assertEqStr(match.str(3), "0");
+                   assertEqStr(match.str(4), "BBBBBB");
+                   matched = boost::regex_search(ac.getSerialized(), match, helper::pflaaRe);
+                   assertTrue(matched);
+                   assertEqStr(match.str(1), "0");
+                   assertEqStr(match.str(2), "0");
+                   assertEqStr(match.str(3), "1000");
+                   assertEqStr(match.str(5), "BBBBBB");
+                   assertEqStr(match.str(9), "8");
                })
         ->test("filter distance", []() {
             AircraftProcessor proc(0);
@@ -77,7 +73,7 @@ void test_data_processor(TestSuitesRunner& runner)
             ac.setPosition({49.0, 8.0, math::doubleToInt(math::FEET_2_M * 3281)});
             proc.setRefered({49.1, 8.1, 0}, 1013.25);
             proc.process(ac);
-            assert(ac.getSerialized(), std::string(""), helper::equalsStr);
+            assertEqStr(ac.getSerialized(), "");
         });
 
     describeParallel<AircraftProcessor>("process relative positions", runner)
@@ -92,17 +88,15 @@ void test_data_processor(TestSuitesRunner& runner)
                    proc.setRefered({-0.1, 0.0, 0}, 1013.25);
                    proc.process(ac);
                    boost::smatch match;
-                   bool matched
-                       = boost::regex_search(ac.getSerialized(), match, helper::pflauRe);
-                   assert(matched, true, helper::equalsBool);
-                   assert(match.str(1), std::string("0"), helper::equalsStr);
-                   assert(match.str(3), std::string("22239"), helper::equalsStr);
-                   matched
-                       = boost::regex_search(ac.getSerialized(), match, helper::pflaaRe);
-                   assert(matched, true, helper::equalsBool);
-                   assert(match.str(1), std::string("22239"), helper::equalsStr);
-                   assert(match.str(2), std::string("0"), helper::equalsStr);
-                   assert(match.str(3), std::string("1000"), helper::equalsStr);
+                   bool matched = boost::regex_search(ac.getSerialized(), match, helper::pflauRe);
+                   assertTrue(matched);
+                   assertEqStr(match.str(1), "0");
+                   assertEqStr(match.str(3), "22239");
+                   matched = boost::regex_search(ac.getSerialized(), match, helper::pflaaRe);
+                   assertTrue(matched);
+                   assertEqStr(match.str(1), "22239");
+                   assertEqStr(match.str(2), "0");
+                   assertEqStr(match.str(3), "1000");
                })
         ->test("Cross Equator N to S",
                []() {
@@ -115,17 +109,15 @@ void test_data_processor(TestSuitesRunner& runner)
                    proc.setRefered({0.1, 0.0, 0}, 1013.25);
                    proc.process(ac);
                    boost::smatch match;
-                   bool matched
-                       = boost::regex_search(ac.getSerialized(), match, helper::pflauRe);
-                   assert(matched, true, helper::equalsBool);
-                   assert(match.str(1), std::string("180"), helper::equalsStr);
-                   assert(match.str(3), std::string("22239"), helper::equalsStr);
-                   matched
-                       = boost::regex_search(ac.getSerialized(), match, helper::pflaaRe);
-                   assert(matched, true, helper::equalsBool);
-                   assert(match.str(1), std::string("-22239"), helper::equalsStr);
-                   assert(match.str(2), std::string("0"), helper::equalsStr);
-                   assert(match.str(3), std::string("1000"), helper::equalsStr);
+                   bool matched = boost::regex_search(ac.getSerialized(), match, helper::pflauRe);
+                   assertTrue(matched);
+                   assertEqStr(match.str(1), "180");
+                   assertEqStr(match.str(3), "22239");
+                   matched = boost::regex_search(ac.getSerialized(), match, helper::pflaaRe);
+                   assertTrue(matched);
+                   assertEqStr(match.str(1), "-22239");
+                   assertEqStr(match.str(2), "0");
+                   assertEqStr(match.str(3), "1000");
                })
         ->test("Cross Northpole",
                []() {
@@ -138,17 +130,15 @@ void test_data_processor(TestSuitesRunner& runner)
                    proc.setRefered({89.9, 180.0, 0}, 1013.25);
                    proc.process(ac);
                    boost::smatch match;
-                   bool matched
-                       = boost::regex_search(ac.getSerialized(), match, helper::pflauRe);
-                   assert(matched, true, helper::equalsBool);
-                   assert(match.str(1), std::string("0"), helper::equalsStr);
-                   assert(match.str(3), std::string("22239"), helper::equalsStr);
-                   matched
-                       = boost::regex_search(ac.getSerialized(), match, helper::pflaaRe);
-                   assert(matched, true, helper::equalsBool);
-                   assert(match.str(1), std::string("22239"), helper::equalsStr);
-                   assert(match.str(2), std::string("0"), helper::equalsStr);
-                   assert(match.str(3), std::string("1000"), helper::equalsStr);
+                   bool matched = boost::regex_search(ac.getSerialized(), match, helper::pflauRe);
+                   assertTrue(matched);
+                   assertEqStr(match.str(1), "0");
+                   assertEqStr(match.str(3), "22239");
+                   matched = boost::regex_search(ac.getSerialized(), match, helper::pflaaRe);
+                   assertTrue(matched);
+                   assertEqStr(match.str(1), "22239");
+                   assertEqStr(match.str(2), "0");
+                   assertEqStr(match.str(3), "1000");
                })
         ->test("Cross Southpole",
                []() {
@@ -161,17 +151,15 @@ void test_data_processor(TestSuitesRunner& runner)
                    proc.setRefered({-89.9, 180.0, 0}, 1013.25);
                    proc.process(ac);
                    boost::smatch match;
-                   bool matched
-                       = boost::regex_search(ac.getSerialized(), match, helper::pflauRe);
-                   assert(matched, true, helper::equalsBool);
-                   assert(match.str(1), std::string("-180"), helper::equalsStr);
-                   assert(match.str(3), std::string("22239"), helper::equalsStr);
-                   matched
-                       = boost::regex_search(ac.getSerialized(), match, helper::pflaaRe);
-                   assert(matched, true, helper::equalsBool);
-                   assert(match.str(1), std::string("-22239"), helper::equalsStr);
-                   assert(match.str(2), std::string("0"), helper::equalsStr);
-                   assert(match.str(3), std::string("1000"), helper::equalsStr);
+                   bool matched = boost::regex_search(ac.getSerialized(), match, helper::pflauRe);
+                   assertTrue(matched);
+                   assertEqStr(match.str(1), "-180");
+                   assertEqStr(match.str(3), "22239");
+                   matched = boost::regex_search(ac.getSerialized(), match, helper::pflaaRe);
+                   assertTrue(matched);
+                   assertEqStr(match.str(1), "-22239");
+                   assertEqStr(match.str(2), "0");
+                   assertEqStr(match.str(3), "1000");
                })
         ->test("Cross 0-Meridian on Equator E to W",
                []() {
@@ -184,17 +172,15 @@ void test_data_processor(TestSuitesRunner& runner)
                    proc.setRefered({0.0, 0.1, 0}, 1013.25);
                    proc.process(ac);
                    boost::smatch match;
-                   bool matched
-                       = boost::regex_search(ac.getSerialized(), match, helper::pflauRe);
-                   assert(matched, true, helper::equalsBool);
-                   assert(match.str(1), std::string("-90"), helper::equalsStr);
-                   assert(match.str(3), std::string("22239"), helper::equalsStr);
-                   matched
-                       = boost::regex_search(ac.getSerialized(), match, helper::pflaaRe);
-                   assert(matched, true, helper::equalsBool);
-                   assert(match.str(1), std::string("0"), helper::equalsStr);
-                   assert(match.str(2), std::string("-22239"), helper::equalsStr);
-                   assert(match.str(3), std::string("1000"), helper::equalsStr);
+                   bool matched = boost::regex_search(ac.getSerialized(), match, helper::pflauRe);
+                   assertTrue(matched);
+                   assertEqStr(match.str(1), "-90");
+                   assertEqStr(match.str(3), "22239");
+                   matched = boost::regex_search(ac.getSerialized(), match, helper::pflaaRe);
+                   assertTrue(matched);
+                   assertEqStr(match.str(1), "0");
+                   assertEqStr(match.str(2), "-22239");
+                   assertEqStr(match.str(3), "1000");
                })
         ->test("Cross 0-Meridian on Equator W to E",
                []() {
@@ -207,17 +193,15 @@ void test_data_processor(TestSuitesRunner& runner)
                    proc.setRefered({0.0, -0.1, 0}, 1013.25);
                    proc.process(ac);
                    boost::smatch match;
-                   bool matched
-                       = boost::regex_search(ac.getSerialized(), match, helper::pflauRe);
-                   assert(matched, true, helper::equalsBool);
-                   assert(match.str(1), std::string("90"), helper::equalsStr);
-                   assert(match.str(3), std::string("22239"), helper::equalsStr);
-                   matched
-                       = boost::regex_search(ac.getSerialized(), match, helper::pflaaRe);
-                   assert(matched, true, helper::equalsBool);
-                   assert(match.str(1), std::string("0"), helper::equalsStr);
-                   assert(match.str(2), std::string("22239"), helper::equalsStr);
-                   assert(match.str(3), std::string("1000"), helper::equalsStr);
+                   bool matched = boost::regex_search(ac.getSerialized(), match, helper::pflauRe);
+                   assertTrue(matched);
+                   assertEqStr(match.str(1), "90");
+                   assertEqStr(match.str(3), "22239");
+                   matched = boost::regex_search(ac.getSerialized(), match, helper::pflaaRe);
+                   assertTrue(matched);
+                   assertEqStr(match.str(1), "0");
+                   assertEqStr(match.str(2), "22239");
+                   assertEqStr(match.str(3), "1000");
                })
         ->test("Cross 0-Meridian on LAT(60) E to W",
                []() {
@@ -230,17 +214,15 @@ void test_data_processor(TestSuitesRunner& runner)
                    proc.setRefered({60.0, 0.1, 0}, 1013.25);
                    proc.process(ac);
                    boost::smatch match;
-                   bool matched
-                       = boost::regex_search(ac.getSerialized(), match, helper::pflauRe);
-                   assert(matched, true, helper::equalsBool);
-                   assert(match.str(1), std::string("-90"), helper::equalsStr);
-                   assert(match.str(3), std::string("11119"), helper::equalsStr);
-                   matched
-                       = boost::regex_search(ac.getSerialized(), match, helper::pflaaRe);
-                   assert(matched, true, helper::equalsBool);
-                   assert(match.str(1), std::string("17"), helper::equalsStr);
-                   assert(match.str(2), std::string("-11119"), helper::equalsStr);
-                   assert(match.str(3), std::string("1000"), helper::equalsStr);
+                   bool matched = boost::regex_search(ac.getSerialized(), match, helper::pflauRe);
+                   assertTrue(matched);
+                   assertEqStr(match.str(1), "-90");
+                   assertEqStr(match.str(3), "11119");
+                   matched = boost::regex_search(ac.getSerialized(), match, helper::pflaaRe);
+                   assertTrue(matched);
+                   assertEqStr(match.str(1), "17");
+                   assertEqStr(match.str(2), "-11119");
+                   assertEqStr(match.str(3), "1000");
                })
         ->test("Cross 0-Meridian on LAT(-60) W to E",
                []() {
@@ -253,41 +235,37 @@ void test_data_processor(TestSuitesRunner& runner)
                    proc.setRefered({-60.0, -0.1, 0}, 1013.25);
                    proc.process(ac);
                    boost::smatch match;
-                   bool matched
-                       = boost::regex_search(ac.getSerialized(), match, helper::pflauRe);
-                   assert(matched, true, helper::equalsBool);
-                   assert(match.str(1), std::string("90"), helper::equalsStr);
-                   assert(match.str(3), std::string("11119"), helper::equalsStr);
-                   matched
-                       = boost::regex_search(ac.getSerialized(), match, helper::pflaaRe);
-                   assert(matched, true, helper::equalsBool);
-                   assert(match.str(1), std::string("-17"), helper::equalsStr);
-                   assert(match.str(2), std::string("11119"), helper::equalsStr);
-                   assert(match.str(3), std::string("1000"), helper::equalsStr);
+                   bool matched = boost::regex_search(ac.getSerialized(), match, helper::pflauRe);
+                   assertTrue(matched);
+                   assertEqStr(match.str(1), "90");
+                   assertEqStr(match.str(3), "11119");
+                   matched = boost::regex_search(ac.getSerialized(), match, helper::pflaaRe);
+                   assertTrue(matched);
+                   assertEqStr(match.str(1), "-17");
+                   assertEqStr(match.str(2), "11119");
+                   assertEqStr(match.str(3), "1000");
                })
-        ->test(
-            "Cross 180-Meridian on Equator E to W",
-            []() {
-                AircraftProcessor proc;
-                Aircraft ac;
-                ac.setId("BBBBBB");
-                ac.setFullInfoAvailable(false);
-                ac.setTargetType(Aircraft::TargetType::TRANSPONDER);
-                ac.setPosition({0.0, -179.9, math::doubleToInt(math::FEET_2_M * 3281)});
-                proc.setRefered({0.0, 179.9, 0}, 1013.25);
-                proc.process(ac);
-                boost::smatch match;
-                bool matched
-                    = boost::regex_search(ac.getSerialized(), match, helper::pflauRe);
-                assert(matched, true, helper::equalsBool);
-                assert(match.str(1), std::string("90"), helper::equalsStr);
-                assert(match.str(3), std::string("22239"), helper::equalsStr);
-                matched = boost::regex_search(ac.getSerialized(), match, helper::pflaaRe);
-                assert(matched, true, helper::equalsBool);
-                assert(match.str(1), std::string("0"), helper::equalsStr);
-                assert(match.str(2), std::string("22239"), helper::equalsStr);
-                assert(match.str(3), std::string("1000"), helper::equalsStr);
-            })
+        ->test("Cross 180-Meridian on Equator E to W",
+               []() {
+                   AircraftProcessor proc;
+                   Aircraft ac;
+                   ac.setId("BBBBBB");
+                   ac.setFullInfoAvailable(false);
+                   ac.setTargetType(Aircraft::TargetType::TRANSPONDER);
+                   ac.setPosition({0.0, -179.9, math::doubleToInt(math::FEET_2_M * 3281)});
+                   proc.setRefered({0.0, 179.9, 0}, 1013.25);
+                   proc.process(ac);
+                   boost::smatch match;
+                   bool matched = boost::regex_search(ac.getSerialized(), match, helper::pflauRe);
+                   assertTrue(matched);
+                   assertEqStr(match.str(1), "90");
+                   assertEqStr(match.str(3), "22239");
+                   matched = boost::regex_search(ac.getSerialized(), match, helper::pflaaRe);
+                   assertTrue(matched);
+                   assertEqStr(match.str(1), "0");
+                   assertEqStr(match.str(2), "22239");
+                   assertEqStr(match.str(3), "1000");
+               })
         ->test("Cross 180-Meridian on Equator W to E",
                []() {
                    AircraftProcessor proc;
@@ -299,66 +277,60 @@ void test_data_processor(TestSuitesRunner& runner)
                    proc.setRefered({0.0, -179.9, 0}, 1013.25);
                    proc.process(ac);
                    boost::smatch match;
-                   bool matched
-                       = boost::regex_search(ac.getSerialized(), match, helper::pflauRe);
-                   assert(matched, true, helper::equalsBool);
-                   assert(match.str(1), std::string("-90"), helper::equalsStr);
-                   assert(match.str(3), std::string("22239"), helper::equalsStr);
-                   matched
-                       = boost::regex_search(ac.getSerialized(), match, helper::pflaaRe);
-                   assert(matched, true, helper::equalsBool);
-                   assert(match.str(1), std::string("0"), helper::equalsStr);
-                   assert(match.str(2), std::string("-22239"), helper::equalsStr);
-                   assert(match.str(3), std::string("1000"), helper::equalsStr);
+                   bool matched = boost::regex_search(ac.getSerialized(), match, helper::pflauRe);
+                   assertTrue(matched);
+                   assertEqStr(match.str(1), "-90");
+                   assertEqStr(match.str(3), "22239");
+                   matched = boost::regex_search(ac.getSerialized(), match, helper::pflaaRe);
+                   assertTrue(matched);
+                   assertEqStr(match.str(1), "0");
+                   assertEqStr(match.str(2), "-22239");
+                   assertEqStr(match.str(3), "1000");
                })
-        ->test("North America",
-               []() {
-                   AircraftProcessor proc;
-                   Aircraft ac;
-                   ac.setId("BBBBBB");
-                   ac.setFullInfoAvailable(false);
-                   ac.setTargetType(Aircraft::TargetType::TRANSPONDER);
-                   ac.setPosition({33.825808, -112.219232,
-                                   math::doubleToInt(math::FEET_2_M * 3281)});
-                   proc.setRefered({33.653124, -112.692253, 0}, 1013.25);
-                   proc.process(ac);
-                   boost::smatch match;
-                   bool matched
-                       = boost::regex_search(ac.getSerialized(), match, helper::pflauRe);
-                   assert(matched, true, helper::equalsBool);
-                   assert(match.str(1), std::string("66"), helper::equalsStr);
-                   assert(match.str(3), std::string("47768"), helper::equalsStr);
-                   matched
-                       = boost::regex_search(ac.getSerialized(), match, helper::pflaaRe);
-                   assert(matched, true, helper::equalsBool);
-                   assert(match.str(1), std::string("19302"), helper::equalsStr);
-                   assert(match.str(2), std::string("43695"), helper::equalsStr);
-                   assert(match.str(3), std::string("1000"), helper::equalsStr);
-               })
-        ->test("South America",
-               []() {
-                   AircraftProcessor proc;
-                   Aircraft ac;
-                   ac.setId("BBBBBB");
-                   ac.setFullInfoAvailable(false);
-                   ac.setTargetType(Aircraft::TargetType::TRANSPONDER);
-                   ac.setPosition({-34.699833, -58.791788,
-                                   math::doubleToInt(math::FEET_2_M * 3281)});
-                   proc.setRefered({-34.680059, -58.818111, 0}, 1013.25);
-                   proc.process(ac);
-                   boost::smatch match;
-                   bool matched
-                       = boost::regex_search(ac.getSerialized(), match, helper::pflauRe);
-                   assert(matched, true, helper::equalsBool);
-                   assert(match.str(1), std::string("132"), helper::equalsStr);
-                   assert(match.str(3), std::string("3260"), helper::equalsStr);
-                   matched
-                       = boost::regex_search(ac.getSerialized(), match, helper::pflaaRe);
-                   assert(matched, true, helper::equalsBool);
-                   assert(match.str(1), std::string("-2199"), helper::equalsStr);
-                   assert(match.str(2), std::string("2407"), helper::equalsStr);
-                   assert(match.str(3), std::string("1000"), helper::equalsStr);
-               })
+        ->test(
+            "North America",
+            []() {
+                AircraftProcessor proc;
+                Aircraft ac;
+                ac.setId("BBBBBB");
+                ac.setFullInfoAvailable(false);
+                ac.setTargetType(Aircraft::TargetType::TRANSPONDER);
+                ac.setPosition({33.825808, -112.219232, math::doubleToInt(math::FEET_2_M * 3281)});
+                proc.setRefered({33.653124, -112.692253, 0}, 1013.25);
+                proc.process(ac);
+                boost::smatch match;
+                bool matched = boost::regex_search(ac.getSerialized(), match, helper::pflauRe);
+                assertTrue(matched);
+                assertEqStr(match.str(1), "66");
+                assertEqStr(match.str(3), "47768");
+                matched = boost::regex_search(ac.getSerialized(), match, helper::pflaaRe);
+                assertTrue(matched);
+                assertEqStr(match.str(1), "19302");
+                assertEqStr(match.str(2), "43695");
+                assertEqStr(match.str(3), "1000");
+            })
+        ->test(
+            "South America",
+            []() {
+                AircraftProcessor proc;
+                Aircraft ac;
+                ac.setId("BBBBBB");
+                ac.setFullInfoAvailable(false);
+                ac.setTargetType(Aircraft::TargetType::TRANSPONDER);
+                ac.setPosition({-34.699833, -58.791788, math::doubleToInt(math::FEET_2_M * 3281)});
+                proc.setRefered({-34.680059, -58.818111, 0}, 1013.25);
+                proc.process(ac);
+                boost::smatch match;
+                bool matched = boost::regex_search(ac.getSerialized(), match, helper::pflauRe);
+                assertTrue(matched);
+                assertEqStr(match.str(1), "132");
+                assertEqStr(match.str(3), "3260");
+                matched = boost::regex_search(ac.getSerialized(), match, helper::pflaaRe);
+                assertTrue(matched);
+                assertEqStr(match.str(1), "-2199");
+                assertEqStr(match.str(2), "2407");
+                assertEqStr(match.str(3), "1000");
+            })
         ->test("North Africa",
                []() {
                    AircraftProcessor proc;
@@ -366,71 +338,64 @@ void test_data_processor(TestSuitesRunner& runner)
                    ac.setId("BBBBBB");
                    ac.setFullInfoAvailable(false);
                    ac.setTargetType(Aircraft::TargetType::TRANSPONDER);
-                   ac.setPosition(
-                       {5.386705, -5.750365, math::doubleToInt(math::FEET_2_M * 3281)});
+                   ac.setPosition({5.386705, -5.750365, math::doubleToInt(math::FEET_2_M * 3281)});
                    proc.setRefered({5.392435, -5.748392, 0}, 1013.25);
                    proc.process(ac);
                    boost::smatch match;
-                   bool matched
-                       = boost::regex_search(ac.getSerialized(), match, helper::pflauRe);
-                   assert(matched, true, helper::equalsBool);
-                   assert(match.str(1), std::string("-161"), helper::equalsStr);
-                   assert(match.str(3), std::string("674"), helper::equalsStr);
-                   matched
-                       = boost::regex_search(ac.getSerialized(), match, helper::pflaaRe);
-                   assert(matched, true, helper::equalsBool);
-                   assert(match.str(1), std::string("-638"), helper::equalsStr);
-                   assert(match.str(2), std::string("-219"), helper::equalsStr);
-                   assert(match.str(3), std::string("1000"), helper::equalsStr);
+                   bool matched = boost::regex_search(ac.getSerialized(), match, helper::pflauRe);
+                   assertTrue(matched);
+                   assertEqStr(match.str(1), "-161");
+                   assertEqStr(match.str(3), "674");
+                   matched = boost::regex_search(ac.getSerialized(), match, helper::pflaaRe);
+                   assertTrue(matched);
+                   assertEqStr(match.str(1), "-638");
+                   assertEqStr(match.str(2), "-219");
+                   assertEqStr(match.str(3), "1000");
                })
-        ->test("South Africa",
-               []() {
-                   AircraftProcessor proc;
-                   Aircraft ac;
-                   ac.setId("BBBBBB");
-                   ac.setFullInfoAvailable(false);
-                   ac.setTargetType(Aircraft::TargetType::TRANSPONDER);
-                   ac.setPosition(
-                       {-23.229517, 15.049683, math::doubleToInt(math::FEET_2_M * 3281)});
-                   proc.setRefered({-26.069244, 15.484389, 0}, 1013.25);
-                   proc.process(ac);
-                   boost::smatch match;
-                   bool matched
-                       = boost::regex_search(ac.getSerialized(), match, helper::pflauRe);
-                   assert(matched, true, helper::equalsBool);
-                   assert(match.str(1), std::string("-8"), helper::equalsStr);
-                   assert(match.str(3), std::string("318804"), helper::equalsStr);
-                   matched
-                       = boost::regex_search(ac.getSerialized(), match, helper::pflaaRe);
-                   assert(matched, true, helper::equalsBool);
-                   assert(match.str(1), std::string("315692"), helper::equalsStr);
-                   assert(match.str(2), std::string("-44437"), helper::equalsStr);
-                   assert(match.str(3), std::string("1000"), helper::equalsStr);
-               })
-        ->test("Australia",
-               []() {
-                   AircraftProcessor proc;
-                   Aircraft ac;
-                   ac.setId("BBBBBB");
-                   ac.setFullInfoAvailable(false);
-                   ac.setTargetType(Aircraft::TargetType::TRANSPONDER);
-                   ac.setPosition({-26.152199, 133.376684,
-                                   math::doubleToInt(math::FEET_2_M * 3281)});
-                   proc.setRefered({-25.278208, 133.366885, 0}, 1013.25);
-                   proc.process(ac);
-                   boost::smatch match;
-                   bool matched
-                       = boost::regex_search(ac.getSerialized(), match, helper::pflauRe);
-                   assert(matched, true, helper::equalsBool);
-                   assert(match.str(1), std::string("179"), helper::equalsStr);
-                   assert(match.str(3), std::string("97188"), helper::equalsStr);
-                   matched
-                       = boost::regex_search(ac.getSerialized(), match, helper::pflaaRe);
-                   assert(matched, true, helper::equalsBool);
-                   assert(match.str(1), std::string("-97183"), helper::equalsStr);
-                   assert(match.str(2), std::string("978"), helper::equalsStr);
-                   assert(match.str(3), std::string("1000"), helper::equalsStr);
-               })
+        ->test(
+            "South Africa",
+            []() {
+                AircraftProcessor proc;
+                Aircraft ac;
+                ac.setId("BBBBBB");
+                ac.setFullInfoAvailable(false);
+                ac.setTargetType(Aircraft::TargetType::TRANSPONDER);
+                ac.setPosition({-23.229517, 15.049683, math::doubleToInt(math::FEET_2_M * 3281)});
+                proc.setRefered({-26.069244, 15.484389, 0}, 1013.25);
+                proc.process(ac);
+                boost::smatch match;
+                bool matched = boost::regex_search(ac.getSerialized(), match, helper::pflauRe);
+                assertTrue(matched);
+                assertEqStr(match.str(1), "-8");
+                assertEqStr(match.str(3), "318804");
+                matched = boost::regex_search(ac.getSerialized(), match, helper::pflaaRe);
+                assertTrue(matched);
+                assertEqStr(match.str(1), "315692");
+                assertEqStr(match.str(2), "-44437");
+                assertEqStr(match.str(3), "1000");
+            })
+        ->test(
+            "Australia",
+            []() {
+                AircraftProcessor proc;
+                Aircraft ac;
+                ac.setId("BBBBBB");
+                ac.setFullInfoAvailable(false);
+                ac.setTargetType(Aircraft::TargetType::TRANSPONDER);
+                ac.setPosition({-26.152199, 133.376684, math::doubleToInt(math::FEET_2_M * 3281)});
+                proc.setRefered({-25.278208, 133.366885, 0}, 1013.25);
+                proc.process(ac);
+                boost::smatch match;
+                bool matched = boost::regex_search(ac.getSerialized(), match, helper::pflauRe);
+                assertTrue(matched);
+                assertEqStr(match.str(1), "179");
+                assertEqStr(match.str(3), "97188");
+                matched = boost::regex_search(ac.getSerialized(), match, helper::pflaaRe);
+                assertTrue(matched);
+                assertEqStr(match.str(1), "-97183");
+                assertEqStr(match.str(2), "978");
+                assertEqStr(match.str(3), "1000");
+            })
         ->test("Central Europe",
                []() {
                    AircraftProcessor proc;
@@ -438,22 +403,19 @@ void test_data_processor(TestSuitesRunner& runner)
                    ac.setId("BBBBBB");
                    ac.setFullInfoAvailable(false);
                    ac.setTargetType(Aircraft::TargetType::TRANSPONDER);
-                   ac.setPosition(
-                       {49.719445, 9.087646, math::doubleToInt(math::FEET_2_M * 3281)});
+                   ac.setPosition({49.719445, 9.087646, math::doubleToInt(math::FEET_2_M * 3281)});
                    proc.setRefered({49.719521, 9.083279, 0}, 1013.25);
                    proc.process(ac);
                    boost::smatch match;
-                   bool matched
-                       = boost::regex_search(ac.getSerialized(), match, helper::pflauRe);
-                   assert(matched, true, helper::equalsBool);
-                   assert(match.str(1), std::string("92"), helper::equalsStr);
-                   assert(match.str(3), std::string("314"), helper::equalsStr);
-                   matched
-                       = boost::regex_search(ac.getSerialized(), match, helper::pflaaRe);
-                   assert(matched, true, helper::equalsBool);
-                   assert(match.str(1), std::string("-8"), helper::equalsStr);
-                   assert(match.str(2), std::string("314"), helper::equalsStr);
-                   assert(match.str(3), std::string("1000"), helper::equalsStr);
+                   bool matched = boost::regex_search(ac.getSerialized(), match, helper::pflauRe);
+                   assertTrue(matched);
+                   assertEqStr(match.str(1), "92");
+                   assertEqStr(match.str(3), "314");
+                   matched = boost::regex_search(ac.getSerialized(), match, helper::pflaaRe);
+                   assertTrue(matched);
+                   assertEqStr(match.str(1), "-8");
+                   assertEqStr(match.str(2), "314");
+                   assertEqStr(match.str(3), "1000");
                })
         ->test("Asia", []() {
             AircraftProcessor proc;
@@ -461,20 +423,18 @@ void test_data_processor(TestSuitesRunner& runner)
             ac.setId("BBBBBB");
             ac.setFullInfoAvailable(false);
             ac.setTargetType(Aircraft::TargetType::TRANSPONDER);
-            ac.setPosition(
-                {32.896360, 103.855837, math::doubleToInt(math::FEET_2_M * 3281)});
+            ac.setPosition({32.896360, 103.855837, math::doubleToInt(math::FEET_2_M * 3281)});
             proc.setRefered({65.900837, 101.570680, 0}, 1013.25);
             proc.process(ac);
             boost::smatch match;
-            bool matched
-                = boost::regex_search(ac.getSerialized(), match, helper::pflauRe);
-            assert(matched, true, helper::equalsBool);
-            assert(match.str(1), std::string("176"), helper::equalsStr);
-            assert(match.str(3), std::string("3673118"), helper::equalsStr);
+            bool matched = boost::regex_search(ac.getSerialized(), match, helper::pflauRe);
+            assertTrue(matched);
+            assertEqStr(match.str(1), "176");
+            assertEqStr(match.str(3), "3673118");
             matched = boost::regex_search(ac.getSerialized(), match, helper::pflaaRe);
-            assert(matched, true, helper::equalsBool);
-            assert(match.str(1), std::string("-3666184"), helper::equalsStr);
-            assert(match.str(2), std::string("225589"), helper::equalsStr);
-            assert(match.str(3), std::string("1000"), helper::equalsStr);
+            assertTrue(matched);
+            assertEqStr(match.str(1), "-3666184");
+            assertEqStr(match.str(2), "225589");
+            assertEqStr(match.str(3), "1000");
         });
 }

--- a/test/units/TestFeedParser.cpp
+++ b/test/units/TestFeedParser.cpp
@@ -34,13 +34,11 @@
 #include "../../src/object/TimeStamp.h"
 #include "../../src/object/Wind.h"
 #include "../Helper.hpp"
-#include "../framework/src/framework.h"
 
 using namespace feed::parser;
-using namespace testsuite;
-using namespace comparator;
+using namespace sctf;
 
-void test_feed_parser(TestSuitesRunner& runner)
+void test_feed_parser(test::TestSuitesRunner& runner)
 {
     describe<SbsParser>("unpack", runner)
         ->test(
@@ -51,58 +49,44 @@ void test_feed_parser(TestSuitesRunner& runner)
                 sbsParser.unpack(
                     "MSG,3,0,0,AAAAAA,0,2017/02/16,20:11:30.772,2017/02/16,20:11:30.772,,1000,,,49.000000,8.000000,,,,,,0",
                     ac);
-                assert(ac.getId(), std::string("AAAAAA"), helper::equalsStr);
-                assert(ac.getTargetType(), object::Aircraft::TargetType::TRANSPONDER,
-                       helper::equalsAtt);
-                assert(ac.getPosition().altitude, math::doubleToInt(math::FEET_2_M * 1000),
-                       helper::equalsInt);
-                assert(ac.getPosition().latitude, 49.0, helper::equalsD);
-                assert(ac.getPosition().longitude, 8.0, helper::equalsD);
-                assert(ac.getFullInfoAvailable(), false, helper::equalsBool);
+                assertStr(ac.getId(), EQUALS, "AAAAAA");
+                assertEquals(ac.getTargetType(), object::Aircraft::TargetType::TRANSPONDER);
+                assertEquals(ac.getPosition().altitude, math::doubleToInt(math::FEET_2_M * 1000));
+                assertEquals(ac.getPosition().latitude, 49.0);
+                assertEquals(ac.getPosition().longitude, 8.0);
+                assertFalse(ac.getFullInfoAvailable());
             })
         ->test(
             "invalid msg",
             []() {
                 SbsParser sbsParser;
                 object::Aircraft ac;
-                assert(
-                    sbsParser.unpack(
-                        "MSG,3,0,0,AAAAAA,0,2017/02/16,20:11:30.772,2017/02/16,20:11:30.772,,,,,,,,,,,,0",
-                        ac),
-                    false, helper::equalsBool);
-                assert(
-                    sbsParser.unpack(
-                        "MSG,3,0,0,,0,2017/02/16,20:11:30.772,2017/02/16,20:11:30.772,,1000,,,,,,,,,,0",
-                        ac),
-                    false, helper::equalsBool);
-                assert(
-                    sbsParser.unpack(
-                        "MSG,3,0,0,AAAAAA,0,2017/02/16,20:11:30.772,2017/02/16,20:11:30.772,,1000,,,49.000000,,,,,,,0",
-                        ac),
-                    false, helper::equalsBool);
-                assert(sbsParser.unpack("MSG,someCrap in, here", ac), false, helper::equalsBool);
-                assert(sbsParser.unpack("MSG,4,0,,,,,,", ac), false, helper::equalsBool);
-                assert(
-                    sbsParser.unpack(
-                        "MSG,3,0,0,AAAAAA,0,2017/02/16,20:11:30.772,2017/02/16,20:11:30.772,,100#0,,,,,,,,,,0",
-                        ac),
-                    false, helper::equalsBool);
-                assert(
-                    sbsParser.unpack(
-                        "MSG,3,0,0,0,2017/02/16,20:11:30.772,2017/02/16,20:11:30.772,,100#0,,,,,,,,,,0",
-                        ac),
-                    false, helper::equalsBool);
-                assert(sbsParser.unpack("", ac), false, helper::equalsBool);
+                assertFalse(sbsParser.unpack(
+                    "MSG,3,0,0,AAAAAA,0,2017/02/16,20:11:30.772,2017/02/16,20:11:30.772,,,,,,,,,,,,0",
+                    ac));
+                assertFalse(sbsParser.unpack(
+                    "MSG,3,0,0,,0,2017/02/16,20:11:30.772,2017/02/16,20:11:30.772,,1000,,,,,,,,,,0",
+                    ac));
+                assertFalse(sbsParser.unpack(
+                    "MSG,3,0,0,AAAAAA,0,2017/02/16,20:11:30.772,2017/02/16,20:11:30.772,,1000,,,49.000000,,,,,,,0",
+                    ac));
+                assertFalse(sbsParser.unpack("MSG,someCrap in, here", ac));
+                assertFalse(sbsParser.unpack("MSG,4,0,,,,,,", ac));
+                assertFalse(sbsParser.unpack(
+                    "MSG,3,0,0,AAAAAA,0,2017/02/16,20:11:30.772,2017/02/16,20:11:30.772,,100#0,,,,,,,,,,0",
+                    ac));
+                assertFalse(sbsParser.unpack(
+                    "MSG,3,0,0,0,2017/02/16,20:11:30.772,2017/02/16,20:11:30.772,,100#0,,,,,,,,,,0",
+                    ac));
+                assertFalse(sbsParser.unpack("", ac));
             })
         ->test("filter height", []() {
             object::Aircraft ac;
             SbsParser tmpSbs;
             tmpSbs.setMaxHeight(0);
-            assert(
-                tmpSbs.unpack(
-                    "MSG,3,0,0,AAAAAA,0,2017/02/16,20:11:30.772,2017/02/16,20:11:30.772,,1000,,,49.000000,8.000000,,,,,,0",
-                    ac),
-                false, helper::equalsBool);
+            assertFalse(tmpSbs.unpack(
+                "MSG,3,0,0,AAAAAA,0,2017/02/16,20:11:30.772,2017/02/16,20:11:30.772,,1000,,,49.000000,8.000000,,,,,,0",
+                ac));
         });
 
     describe<AprsParser>("unpack", runner)
@@ -111,62 +95,47 @@ void test_feed_parser(TestSuitesRunner& runner)
             []() {
                 AprsParser aprsParser;
                 object::Aircraft ac;
-                assert(
-                    aprsParser.unpack(
-                        "FLRAAAAAA>APRS,qAS,XXXX:/100715h4900.00N/00800.00E'/A=000000 !W19! id06AAAAAA",
-                        ac),
-                    true, helper::equalsBool);
-                assert(
-                    aprsParser.unpack(
-                        "ICAAAAAAA>APRS,qAR:/081733h4900.00N/00800.00EX180/003/A=000000 !W38! id0DAAAAAA -138fpm +0.0rot 6.2dB 0e +4.2kHz gps4x4",
-                        ac),
-                    true, helper::equalsBool);
-                assert(
-                    aprsParser.unpack(
-                        "FLRAAAAAA>APRS,qAS,XXXX:/100715h4900.00S\\00800.00E^276/014/A=000000 !W07! id22AAAAAA -019fpm +3.7rot 37.8dB 0e -51.2kHz gps2x4",
-                        ac),
-                    true, helper::equalsBool);
-                assert(
-                    aprsParser.unpack(
-                        "FLRAAAAAA>APRS,qAS,XXXX:/074548h4900.00N/00800.00W'000/000/A=000000 id0AAAAAAA +000fpm +0.0rot 5.5dB 3e -4.3kHz",
-                        ac),
-                    true, helper::equalsBool);
-                assert(ac.getId(), std::string("AAAAAA"), helper::equalsStr);
-                assert(ac.getTargetType(), object::Aircraft::TargetType::FLARM, helper::equalsAtt);
-                assert(ac.getPosition().altitude, 0, helper::equalsInt);
-                assert(ac.getPosition().latitude, 49.0, helper::equalsD);
-                assert(ac.getPosition().longitude, -8.0, helper::equalsD);
-                assert(ac.getFullInfoAvailable(), true, helper::equalsBool);
+                assertTrue(aprsParser.unpack(
+                    "FLRAAAAAA>APRS,qAS,XXXX:/100715h4900.00N/00800.00E'/A=000000 !W19! id06AAAAAA",
+                    ac));
+                assertTrue(aprsParser.unpack(
+                    "ICAAAAAAA>APRS,qAR:/081733h4900.00N/00800.00EX180/003/A=000000 !W38! id0DAAAAAA -138fpm +0.0rot 6.2dB 0e +4.2kHz gps4x4",
+                    ac));
+                assertTrue(aprsParser.unpack(
+                    "FLRAAAAAA>APRS,qAS,XXXX:/100715h4900.00S\\00800.00E^276/014/A=000000 !W07! id22AAAAAA -019fpm +3.7rot 37.8dB 0e -51.2kHz gps2x4",
+                    ac));
+                assertTrue(aprsParser.unpack(
+                    "FLRAAAAAA>APRS,qAS,XXXX:/074548h4900.00N/00800.00W'000/000/A=000000 id0AAAAAAA +000fpm +0.0rot 5.5dB 3e -4.3kHz",
+                    ac));
+                assertEqStr(ac.getId(), "AAAAAA");
+                assertEquals(ac.getTargetType(), object::Aircraft::TargetType::FLARM);
+                assertEquals(ac.getPosition().altitude, 0);
+                assertEquals(ac.getPosition().latitude, 49.0);
+                assertEquals(ac.getPosition().longitude, -8.0);
+                assertTrue(ac.getFullInfoAvailable());
             })
         ->test(
             "invalid msg",
             []() {
                 AprsParser aprsParser;
                 object::Aircraft ac;
-                assert(
-                    aprsParser.unpack(
-                        "Valhalla>APRS,TCPIP*,qAC,GLIDERN2:/074555h4900.00NI00800.00E&/A=000000 CPU:4.0 RAM:242.7/458.8MB NTP:0.8ms/-28.6ppm +56.2C RF:+38+2.4ppm/+1.7dB",
-                        ac),
-                    false, helper::equalsBool);
-                assert(
-                    aprsParser.unpack(
-                        "# aprsc 2.0.14-g28c5a6a 29 Jun 2014 07:46:15 GMT SERVER1 00.000.00.000:14580",
-                        ac),
-                    false, helper::equalsBool);
-                assert(aprsParser.unpack("", ac), false, helper::equalsBool);
-                assert(aprsParser.unpack(
-                           "FLRAAAAAA>APRS,qAS,XXXX:/100715h4900.00N/00800.00E'/A=000000 ", ac),
-                       false, helper::equalsBool);
+                assertFalse(aprsParser.unpack(
+                    "Valhalla>APRS,TCPIP*,qAC,GLIDERN2:/074555h4900.00NI00800.00E&/A=000000 CPU:4.0 RAM:242.7/458.8MB NTP:0.8ms/-28.6ppm +56.2C RF:+38+2.4ppm/+1.7dB",
+                    ac));
+                assertFalse(aprsParser.unpack(
+                    "# aprsc 2.0.14-g28c5a6a 29 Jun 2014 07:46:15 GMT SERVER1 00.000.00.000:14580",
+                    ac));
+                assertFalse(aprsParser.unpack("", ac));
+                assertFalse(aprsParser.unpack(
+                    "FLRAAAAAA>APRS,qAS,XXXX:/100715h4900.00N/00800.00E'/A=000000 ", ac));
             })
         ->test("filter height", []() {
             AprsParser tmpAprs;
             tmpAprs.setMaxHeight(0);
             object::Aircraft ac;
-            assert(
-                tmpAprs.unpack(
-                    "FLRAAAAAA>APRS,qAS,XXXX:/074548h4900.00N/00800.00W'000/000/A=001000 id0AAAAAAA +000fpm +0.0rot 5.5dB 3e -4.3kHz",
-                    ac),
-                false, helper::equalsBool);
+            assertFalse(tmpAprs.unpack(
+                "FLRAAAAAA>APRS,qAS,XXXX:/074548h4900.00N/00800.00W'000/000/A=001000 id0AAAAAAA +000fpm +0.0rot 5.5dB 3e -4.3kHz",
+                ac));
         });
 
     describe<WindParser>("unpack", runner)
@@ -175,16 +144,15 @@ void test_feed_parser(TestSuitesRunner& runner)
                    WindParser windParser;
                    object::Wind wind;
                    std::string mwv("$WIMWV,242.8,R,6.9,N,A*20\r\n");
-                   assert(windParser.unpack(mwv, wind), true, helper::equalsBool);
-                   assert(wind.getSerialized(), mwv, helper::equalsStr);
+                   assertTrue(windParser.unpack(mwv, wind));
+                   assertEquals(wind.getSerialized(), mwv);
                })
         ->test("invalid msg", []() {
             WindParser windParser;
             object::Wind wind;
-            assert(windParser.unpack("$YXXDR,C,19.3,C,BRDT,U,11.99,V,BRDV*75", wind), false,
-                   helper::equalsBool);
-            assert(windParser.unpack("Someone sent other stuff", wind), false, helper::equalsBool);
-            assert(windParser.unpack("", wind), false, helper::equalsBool);
+            assertFalse(windParser.unpack("$YXXDR,C,19.3,C,BRDT,U,11.99,V,BRDV*75", wind));
+            assertFalse(windParser.unpack("Someone sent other stuff", wind));
+            assertFalse(windParser.unpack("", wind));
         });
 
     describe<AtmosphereParser>("unpack", runner)
@@ -193,61 +161,51 @@ void test_feed_parser(TestSuitesRunner& runner)
                    AtmosphereParser atmParser;
                    object::Atmosphere atm;
                    std::string mda("$WIMDA,29.7987,I,1.0091,B,14.8,C,,,,,,,,,,,,,,*3E\r\n");
-                   assert(atmParser.unpack(mda, atm), true, helper::equalsBool);
-                   assert(atm.getPressure(), 1009.1, helper::equalsD);
-                   assert(atm.getSerialized(), mda, helper::equalsStr);
+                   assertTrue(atmParser.unpack(mda, atm));
+                   assertEquals(atm.getPressure(), 1009.1);
+                   assertEquals(atm.getSerialized(), mda);
                })
         ->test("invalid msg", []() {
             AtmosphereParser atmParser;
             object::Atmosphere atm;
-            assert(atmParser.unpack("$YXXDR,C,19.3,C,BRDT,U,11.99,V,BRDV*75", atm), false,
-                   helper::equalsBool);
-            assert(atmParser.unpack("Someone sent other stuff", atm), false, helper::equalsBool);
-            assert(atmParser.unpack("$WIMDA,29.7987,I,1.0091,14.8,,,,,,,,,,,,,,*3F", atm), false,
-                   helper::equalsBool);
-            assert(atmParser.unpack("$WIMDA,", atm), false, helper::equalsBool);
-            assert(atmParser.unpack("$WIMDA,29.7987,I,1.0#091,B,14.8,C,,,,,,,,,,,,,,*1d", atm),
-                   false, helper::equalsBool);
-            assert(atmParser.unpack("", atm), false, helper::equalsBool);
+            assertFalse(atmParser.unpack("$YXXDR,C,19.3,C,BRDT,U,11.99,V,BRDV*75", atm));
+            assertFalse(atmParser.unpack("Someone sent other stuff", atm));
+            assertFalse(atmParser.unpack("$WIMDA,29.7987,I,1.0091,14.8,,,,,,,,,,,,,,*3F", atm));
+            assertFalse(atmParser.unpack("$WIMDA,", atm));
+            assertFalse(
+                atmParser.unpack("$WIMDA,29.7987,I,1.0#091,B,14.8,C,,,,,,,,,,,,,,*1d", atm));
+            assertFalse(atmParser.unpack("", atm));
         });
 
     describe<GpsParser>("unpack", runner)
-        ->test(
-            "valid msg",
-            []() {
-                GpsParser gpsParser;
-                object::GpsPosition pos;
-                assert(gpsParser.unpack(
-                           "$GPGGA,183552,5000.0466,N,00815.7555,E,1,05,1,105,M,48.0,M,,*49", pos),
-                       true, helper::equalsBool);
-                assert(
-                    gpsParser.unpack(
-                        "$GPGGA,183552,5000.0466,N,00815.7555,E,1,05,1,105,M,48.0,M,,*49\r\n", pos),
-                    true, helper::equalsBool);
-                assert(
-                    gpsParser.unpack(
-                        "$GPGGA,183552,5000.0466,S,00815.7555,W,1,05,1,105,M,48.0,M,,*46\n", pos),
-                    true, helper::equalsBool);
-                assert(pos.getDilution(), 1.0, helper::equalsD);
-                assert(pos.getFixQuality(), 1, helper::equalsInt);
-                assert(pos.getNrOfSatellites(), 5, helper::equalsInt);
-                assert(pos.getGeoid(), 48.0, helper::equalsD);
-                assert(pos.getPosition().latitude, -math::dmToDeg(5000.0466), helper::equalsD);
-                assert(pos.getPosition().longitude, -math::dmToDeg(815.7555), helper::equalsD);
-                assert(pos.getPosition().altitude, 105, helper::equalsInt);
-            })
+        ->test("valid msg",
+               []() {
+                   GpsParser gpsParser;
+                   object::GpsPosition pos;
+                   assertTrue(gpsParser.unpack(
+                       "$GPGGA,183552,5000.0466,N,00815.7555,E,1,05,1,105,M,48.0,M,,*49", pos));
+                   assertTrue(gpsParser.unpack(
+                       "$GPGGA,183552,5000.0466,N,00815.7555,E,1,05,1,105,M,48.0,M,,*49\r\n", pos));
+                   assertTrue(gpsParser.unpack(
+                       "$GPGGA,183552,5000.0466,S,00815.7555,W,1,05,1,105,M,48.0,M,,*46\n", pos));
+                   assertEquals(pos.getDilution(), 1.0);
+                   assertEquals(pos.getFixQuality(), 1);
+                   assertEquals(pos.getNrOfSatellites(), 5);
+                   assertEquals(pos.getGeoid(), 48.0);
+                   assertEquals(pos.getPosition().latitude, -math::dmToDeg(5000.0466));
+                   assertEquals(pos.getPosition().longitude, -math::dmToDeg(815.7555));
+                   assertEquals(pos.getPosition().altitude, 105);
+               })
         ->test("invalid msg", []() {
             GpsParser gpsParser;
             object::GpsPosition pos;
-            assert(gpsParser.unpack(
-                       "$GPGGA,183552,5000.0466,N,00815.7555,E,1,05,1,105,M,48.0,M,,*59\r\n", pos),
-                   false, helper::equalsBool);
-            assert(
-                gpsParser.unpack("$GPGGA,183552,N,00815.7555,E,1,05,1,105,M,48.0,M,,*59\r\n", pos),
-                false, helper::equalsBool);
-            assert(gpsParser.unpack("$GPGGA,\r\n", pos), false, helper::equalsBool);
-            assert(gpsParser.unpack("", pos), false, helper::equalsBool);
-            assert(gpsParser.unpack("$GPGGA,183552,N,00815.7555,E,1,05,1,105,M,48.0,M,,*\r\n", pos),
-                   false, helper::equalsBool);
+            assertFalse(gpsParser.unpack(
+                "$GPGGA,183552,5000.0466,N,00815.7555,E,1,05,1,105,M,48.0,M,,*59\r\n", pos));
+            assertFalse(
+                gpsParser.unpack("$GPGGA,183552,N,00815.7555,E,1,05,1,105,M,48.0,M,,*59\r\n", pos));
+            assertFalse(gpsParser.unpack("$GPGGA,\r\n", pos));
+            assertFalse(gpsParser.unpack("", pos));
+            assertFalse(
+                gpsParser.unpack("$GPGGA,183552,N,00815.7555,E,1,05,1,105,M,48.0,M,,*\r\n", pos));
         });
 }

--- a/test/units/TestFeedParser.cpp
+++ b/test/units/TestFeedParser.cpp
@@ -36,10 +36,6 @@
 #include "../Helper.hpp"
 #include "../framework/src/framework.h"
 
-#ifdef assert
-#undef assert
-#endif
-
 using namespace feed::parser;
 using namespace testsuite;
 using namespace comparator;

--- a/test/units/TestMath.cpp
+++ b/test/units/TestMath.cpp
@@ -23,50 +23,50 @@
 
 #include "../../src/Math.hpp"
 #include "../Helper.hpp"
-#include "../framework/src/framework.h"
 
-using namespace testsuite;
-using namespace comparator;
+using namespace sctf;
+using namespace test;
+using namespace comp;
 
 void test_math(TestSuitesRunner& runner)
 {
     describe("math utils", runner, "math")
         ->test("radian",
                []() {
-                   assert(math::radian(45.0), 0.785398, helper::equalsD);
-                   assert(math::radian(0.0), 0.0, helper::equalsD);
-                   assert(math::radian(360.0), 6.28319, helper::equalsD);
+                   assertEquals(math::radian(45.0), 0.785398);
+                   assertEquals(math::radian(0.0), 0.0);
+                   assertEquals(math::radian(360.0), 6.28319);
                })
         ->test("degree",
                []() {
-                   assert(math::degree(0.785398), 45.0, helper::equalsD);
-                   assert(math::degree(0.0), 0.0, helper::equalsD);
-                   assert(math::degree(6.28319), 360.0, helper::equalsD);
+                   assertEquals(math::degree(0.785398), 45.0);
+                   assertEquals(math::degree(0.0), 0.0);
+                   assertEquals(math::degree(6.28319), 360.0);
                })
         ->test("doubleToInt",
                []() {
-                   assert(math::doubleToInt(0.0), 0, helper::equalsInt);
-                   assert(math::doubleToInt(1.4), 1, helper::equalsInt);
-                   assert(math::doubleToInt(1.5), 2, helper::equalsInt);
-                   assert(math::doubleToInt(-1.4), -1, helper::equalsInt);
-                   assert(math::doubleToInt(-1.5), -2, helper::equalsInt);
+                   assertEquals(math::doubleToInt(0.0), 0);
+                   assertEquals(math::doubleToInt(1.4), 1);
+                   assertEquals(math::doubleToInt(1.5), 2);
+                   assertEquals(math::doubleToInt(-1.4), -1);
+                   assertEquals(math::doubleToInt(-1.5), -2);
                })
         ->test("dmToDeg",
                []() {
-                   assert(math::dmToDeg(0.0), 0.0, helper::equalsD);
-                   assert(math::dmToDeg(9030.50), 90.508333, helper::equalsD);
-                   assert(math::dmToDeg(18000.0), 180.0, helper::equalsD);
-                   assert(math::dmToDeg(-4512.3456), 45.205760, helper::equalsD);
+                   assertEquals(math::dmToDeg(0.0), 0.0);
+                   assertEquals(math::dmToDeg(9030.50), 90.508333);
+                   assertEquals(math::dmToDeg(18000.0), 180.0);
+                   assertEquals(math::dmToDeg(-4512.3456), 45.205760);
                })
         ->test("calcIcaoHeight",
                []() {
-                   assert(math::icaoHeight(0.0), 44331, helper::equalsInt);
-                   assert(math::icaoHeight(1013.25), 0, helper::equalsInt);
-                   assert(math::icaoHeight(980.0), 281, helper::equalsInt);
+                   assertEquals(math::icaoHeight(0.0), 44331);
+                   assertEquals(math::icaoHeight(1013.25), 0);
+                   assertEquals(math::icaoHeight(980.0), 281);
                })
         ->test("checksum", []() {
-            assert(math::checksum("", sizeof("")), 0, helper::equalsInt);
-            assert(math::checksum("\0", sizeof("\0")), 0, helper::equalsInt);
-            assert(math::checksum("$abc*", sizeof("$abc*")), 96, helper::equalsInt);
+            assertEquals(math::checksum("", sizeof("")), 0);
+            assertEquals(math::checksum("\0", sizeof("\0")), 0);
+            assertEquals(math::checksum("$abc*", sizeof("$abc*")), 96);
         });
 }

--- a/test/units/TestMath.cpp
+++ b/test/units/TestMath.cpp
@@ -25,10 +25,8 @@
 #include "../Helper.hpp"
 
 using namespace sctf;
-using namespace test;
-using namespace comp;
 
-void test_math(TestSuitesRunner& runner)
+void test_math(test::TestSuitesRunner& runner)
 {
     describe("math utils", runner, "math")
         ->test("radian",

--- a/test/units/TestMath.cpp
+++ b/test/units/TestMath.cpp
@@ -25,10 +25,6 @@
 #include "../Helper.hpp"
 #include "../framework/src/framework.h"
 
-#ifdef assert
-#undef assert
-#endif
-
 using namespace testsuite;
 using namespace comparator;
 

--- a/test/units/TestObject.cpp
+++ b/test/units/TestObject.cpp
@@ -20,8 +20,10 @@
  */
 
 #include "../../src/object/Aircraft.h"
-#include "../../src/object/Climate.hpp"
+#include "../../src/object/Atmosphere.h"
 #include "../../src/object/GpsPosition.h"
+#include "../../src/object/TimeStamp.h"
+#include "../../src/object/Wind.h"
 #include "../Helper.hpp"
 #include "../framework/src/framework.h"
 

--- a/test/units/TestObject.cpp
+++ b/test/units/TestObject.cpp
@@ -25,11 +25,9 @@
 #include "../../src/object/TimeStamp.h"
 #include "../../src/object/Wind.h"
 #include "../Helper.hpp"
-#include "../framework/src/framework.h"
 
 using namespace object;
-using namespace testsuite;
-using namespace comparator;
+using namespace sctf;
 
-void test_object(TestSuitesRunner& runner)
+void test_object(test::TestSuitesRunner& runner)
 {}

--- a/test/units/TestObject.cpp
+++ b/test/units/TestObject.cpp
@@ -27,10 +27,6 @@
 #include "../Helper.hpp"
 #include "../framework/src/framework.h"
 
-#ifdef assert
-#undef assert
-#endif
-
 using namespace object;
 using namespace testsuite;
 using namespace comparator;


### PR DESCRIPTION
## Summary

Where possible use a given timestamp to validate an  updates age.
Also make priority static again, so every to-lower-prio Feed source switch takes a fixed amount of cycles without an update. This should reduce offsets between datasources while still allow priorisation.

## Main changes

+ Allow updates only on newer timestamp
+ Remove attempt counters
+ Fixed amount of cycles (not attempts) until lower-prio updates are taken

## Related Issues/Milestones



## Severity

severe

## Note

