### PR TITLE
impl a backoff timeout

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,7 @@ list(REMOVE_ITEM vfrb_test_sources ${PROJECT_SOURCE_DIR}/src/object/impl/DateTim
 #list(REMOVE_ITEM vfrb_prof_sources ${PROJECT_SOURCE_DIR}/src/main.cpp)
 
 set(CMAKE_BUILD_TYPE staged)
-set(CMAKE_CXX_FLAGS_STAGED "-Wall -Wextra -Wpedantic -Werror -Wno-error=attributes")
+set(CMAKE_CXX_FLAGS_STAGED "-Wall -Wextra -Wpedantic -Wnon-virtual-dtor -Werror -Wno-error=attributes")
 
 if(DEFINED BOOST_STATIC)
     message(STATUS "Linking boost statically")

--- a/include/client/Client.h
+++ b/include/client/Client.h
@@ -28,6 +28,7 @@
 #include "net/Endpoint.hpp"
 #include "util/class_utils.h"
 
+#include "TimeoutBackoff.h"
 #include "types.h"
 
 namespace vfrb::feed
@@ -52,6 +53,7 @@ protected:
         STOPPING
     };
 
+    TimeoutBackoff                 m_backoff;
     s_ptr<net::Connector>          m_connector;            /// Connector interface
     State                          m_state = State::NONE;  /// Run state indicator
     net::Endpoint const            m_endpoint;             /// Remote endpoint

--- a/include/parameters.h
+++ b/include/parameters.h
@@ -34,25 +34,13 @@
 namespace vfrb::param
 {
 /**
- * Input-clients wait for this duration, in seconds, until
- * attempting a connect (reconnect).
- * [1 <= x]
- * This value depends on Your infrastructure.
- * E.g. if Your receivers run on different hosts, which get
- * turned on 1 hour after VFR-B, it is pointless to attempt connect
- * every second. As well as waiting 1 hour if all receivers are up
- * after 2 minutes.
- */
-inline constexpr auto CLIENT_CONNECT_WAIT_TIMEVAL = 120;
-
-/**
  * Due to unstable hardware/drivers, it became apparent that
  * it is necessary to timeout the wind-sensors input.
  * [1 <= x]
  * A good way is to set this value to 1.5 * Y, where
  * Y is the time interval the wind-sensor sends its data.
  */
-inline constexpr auto WINDCLIENT_RECEIVE_TIMEOUT = 5;
+inline constexpr auto WINDCLIENT_RECEIVE_TIMEOUT = 3;
 
 /**
  * Max amount of clients, which can connect to the VFR-B's

--- a/src/client/AprscClient.cpp
+++ b/src/client/AprscClient.cpp
@@ -87,6 +87,7 @@ void AprscClient::handleLogin(ErrorCode error)
         if (error == ErrorCode::SUCCESS)
         {
             m_state = State::RUNNING;
+            m_backoff.reset();
             logger.info(LOG_PREFIX, "connected to ", m_endpoint.host, ":", m_endpoint.port);
             sendKeepAlive();
             read();

--- a/src/client/Client.cpp
+++ b/src/client/Client.cpp
@@ -31,8 +31,6 @@
 #include "feed/Feed.h"
 #include "util/Logger.hpp"
 
-#include "parameters.h"
-
 static auto const& logger = vfrb::Logger::instance();
 
 using namespace vfrb::client::net;
@@ -96,7 +94,7 @@ void Client::reconnect()
 void Client::timedConnect()
 {
     m_connector->onTimeout(std::bind(&Client::handleTimedConnect, this, std::placeholders::_1),
-                           param::CLIENT_CONNECT_WAIT_TIMEVAL);
+                           m_backoff.next());
 }
 
 void Client::stop()

--- a/src/client/GpsdClient.cpp
+++ b/src/client/GpsdClient.cpp
@@ -79,6 +79,7 @@ void GpsdClient::handleWatch(ErrorCode error)
         if (error == ErrorCode::SUCCESS)
         {
             m_state = State::RUNNING;
+            m_backoff.reset();
             logger.info(LOG_PREFIX, "connected to ", m_endpoint.host, ":", m_endpoint.port);
             read();
         }

--- a/src/client/SensorClient.cpp
+++ b/src/client/SensorClient.cpp
@@ -67,6 +67,7 @@ void SensorClient::handleConnect(ErrorCode error)
         if (error == ErrorCode::SUCCESS)
         {
             m_state = State::RUNNING;
+            m_backoff.reset();
             logger.info(LOG_PREFIX, "connected to ", m_endpoint.host, ":", m_endpoint.port);
             m_connector->onTimeout(std::bind(&SensorClient::checkDeadline, this, std::placeholders::_1),
                                    param::WINDCLIENT_RECEIVE_TIMEOUT);


### PR DESCRIPTION
## Summary

Implement a backoff strategy for client connects.

## Main changes

+ Remove fixed client reconnect timeout
+ Add backoff strategy class to clients

## Related Issues/Milestones

+ https://github.com/Jarthianur/VirtualFlightRadar-Backend/issues/57

## Severity



## Note

